### PR TITLE
Make run command output bin inside ${GOLANG}/bin for being coherent with readme

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ clean:
 build:  clean
 	@echo Building...
 	${GO_BUILD_ENVVARS} go build \
-		-o sws -ldflags "-X main.version=${VERSION} -X main.commitHash=${COMMIT_HASH}"
+		-o ${GOPATH}/bin/sws -ldflags "-X main.version=${VERSION} -X main.commitHash=${COMMIT_HASH}"
 
 install:
 	@echo Installing...


### PR DESCRIPTION
```bash
$ make build
Cleaning...
Building...
GOOS=linux GOARCH=amd64 CGO_ENABLED=0  go build \
	-o sws -ldflags "-X main.version=0.0.1.Final-SNAPSHOT -X main.commitHash=3793fa21e5f854019ba31010f3f61a8fa1754d0f"

$ make run
Running...
make: sws: Command not found
make: *** [run] Error 127
```

It looks like `-o` flag on `go build` generates the `sws` bin in same folder. So, `make run` doesn't find the bin.
