### PR TITLE
make docker builds go faster in the normal repeat case

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,7 @@ docker:
 	@mkdir -p _output/docker
 	@cp -r deploy/docker/* _output/docker
 	@cp ${GOPATH}/bin/sws _output/docker
-	@npm --prefix _output/docker/npm -g install swsui
+	@if [ ! -d "_output/docker/npm" ]; then npm --prefix _output/docker/npm -g install swsui; fi
 	docker build -t ${DOCKER_TAG} _output/docker
 
 openshift-deploy: openshift-undeploy


### PR DESCRIPTION
If we have not yet pulled down the UI from npm, "make docker" will do so.
Otherwise, the npm install is skipped.
If you want to pull down the UI again, just do a "make clean" and the docker
target will do the npm install again (e.g. "make clean docker")