### PR TITLE
Prometheus Client Tweaks

### DIFF
--- a/handlers/root.go
+++ b/handlers/root.go
@@ -95,7 +95,7 @@ func demoFetchAllServicesAndPrintThem(w http.ResponseWriter) {
 			}
 
 			fmt.Fprintf(w, "Dependencies: \n")
-			if incomeServices, err := prometheusClient.GetIncomeServices(namespace, service); err != nil {
+			if incomeServices, err := prometheusClient.GetSourceServices(namespace, service); err != nil {
 				log.Error(err)
 				return
 			} else {

--- a/prometheus/client.go
+++ b/prometheus/client.go
@@ -16,17 +16,16 @@ import (
 
 const istio_request_query = "istio_request_count{destination_service=~\"%s.%s.*\"}"
 
-
 // Client for Prometheus API.
 // It hides the way we query Prometheus offering a layer with a high level defined API.
-type PrometheusClient struct {
+type Client struct {
 	p8s api.Client
 }
 
 // NewClient creates a new client to the Prometheus API.
 // It returns an error on any problem.
-func NewClient() (*PrometheusClient, error) {
-	client := PrometheusClient{}
+func NewClient() (*Client, error) {
+	client := Client{}
 	if config.Get() == nil {
 		return nil, errors.New("config.Get() must be not null")
 	}
@@ -38,11 +37,11 @@ func NewClient() (*PrometheusClient, error) {
 	return &client, nil
 }
 
-// It returns a map of incoming services for a given service identified by its namespace and service name.
+// GetSourceServices returns a map of source services for a given service identified by its namespace and service name.
 // Returned map has a destination version as a key and a "<origin service>/<origin version>" pair as value.
 // Destination service is not included in the map as it is passed as argument.
 // It returns an error on any problem.
-func (in *PrometheusClient) GetIncomeServices(namespace string, servicename string) (map[string]string, error) {
+func (in *Client) GetSourceServices(namespace string, servicename string) (map[string]string, error) {
 	query := fmt.Sprintf(istio_request_query, servicename, namespace)
 	api := v1.NewAPI(in.p8s)
 	result, err := api.Query(context.Background(), query, time.Now())
@@ -58,11 +57,16 @@ func (in *PrometheusClient) GetIncomeServices(namespace string, servicename stri
 			index := fmt.Sprintf("%s", metric["destination_version"])
 			sourceService := string(metric["source_service"])
 			// .svc sufix is a pure Istio label, I guess we can skip it at the moment for clarity
-			if i:= strings.Index(sourceService, ".svc"); i > 0 {
+			if i := strings.Index(sourceService, ".svc"); i > 0 {
 				sourceService = sourceService[:i]
 			}
 			routes[index] = fmt.Sprintf("%s/%s", sourceService, metric["source_version"])
 		}
 	}
 	return routes, nil
+}
+
+// API returns the Prometheus V1 HTTP API for performing calls not supported natively by thi client
+func (in *Client) Api() v1.API {
+	return v1.NewAPI(in.p8s)
 }


### PR DESCRIPTION
- rename PrometheusClient to Client as using it as an imported type is
  verbose:

  f(c prometheus.PrometheusClient) changes to f(c prometheus.Client)

- Add function to just get the prom api in order to make calls that are not
  [yet] formalized in this client.

- rename GetIncomeServices() to getSourceServices() as the original name
  does not read well in English and "Source" is more in line with the
  Istio Metric label terminology.
  - Also, tweak function comment to be match convention of leading with
    the name