### PR TITLE
Allow deployments to be successful using minishift

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 VERSION ?= 0.0.1.Final-SNAPSHOT
 COMMIT_HASH ?= $(shell git rev-parse HEAD)
 
-DOCKER_NAME = jmazzitelli/sws
+DOCKER_NAME ?= jmazzitelli/sws
 DOCKER_VERSION ?= dev
 DOCKER_TAG = ${DOCKER_NAME}:${DOCKER_VERSION}
 
@@ -74,7 +74,7 @@ docker:
 openshift-deploy: openshift-undeploy
 	@echo Deploying to OpenShift
 	oc create -f deploy/openshift/sws-configmap.yaml -n ${NAMESPACE}
-	oc process -f deploy/openshift/sws.yaml -p IMAGE_VERSION=${DOCKER_VERSION} -p NAMESPACE=${NAMESPACE}| oc create -n ${NAMESPACE} -f -
+	oc process -f deploy/openshift/sws.yaml -p IMAGE_NAME=${DOCKER_NAME} -p IMAGE_VERSION=${DOCKER_VERSION} -p NAMESPACE=${NAMESPACE} | oc create -n ${NAMESPACE} -f -
 
 openshift-undeploy:
 	@echo Undeploying from OpenShift

--- a/deploy/openshift/sws.yaml
+++ b/deploy/openshift/sws.yaml
@@ -6,6 +6,9 @@ metadata:
   name: sws
   app: sws
 parameters:
+- description: The name of the image to use
+  name: IMAGE_NAME
+  value: jmazzitelli/sws
 - description: The version of the image to use
   name: IMAGE_VERSION
   value: dev
@@ -61,7 +64,7 @@ objects:
       spec:
         serviceAccount: sws
         containers:
-        - image: jmazzitelli/sws:${IMAGE_VERSION}
+        - image: ${IMAGE_NAME}:${IMAGE_VERSION}
           name: sws
           command:
             - "/opt/sws/sws"


### PR DESCRIPTION
I have OpenShift installed through minishift. It means that when you are using `make openshift-deploy` the sws image built is not available within the cluster. Then, OpenShift goes to docker.io to look for it but it only finds the @jmazzitelli latest version.

This is only a humble proposal. I don't know if it has any sense to do it this way, so please let me know :)

1. I create a repo into docker.io image registry
2. I changed `Makefile` to allow the name of the docker image as a parameter.

This way, openshift goes to my personal docker.io account and pulls it from there.

```bash
export DOCKER_NAME=xeviknal/sws
export DOCKER_VERSION=latest
make docker
docker push xeviknal/sws:latest
make openshift-deploy
```
Here is the output:

![minishift-deployment-own-dockerio](https://user-images.githubusercontent.com/613814/36274266-7115e812-1287-11e8-93c1-41b60b3410ab.png)


Should perhaps add another target to Makefile for this minishift deploy? 
```bash
minishift-deploy:
  @echo Pushing current docker image to ${DOCKER_TAG}
  docker push ${DOCKER_TAG}
  openshift-deploy
```

Just an idea :dancing_men: 
