### PR TITLE
Makefile target for pushing docker image to docker hub

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -80,6 +80,10 @@ docker:
 	@if [ ! -d "_output/docker/npm" ]; then npm --prefix _output/docker/npm -g install swsui; fi
 	docker build -t ${DOCKER_TAG} _output/docker
 
+docker-push:
+	@echo Pushing current docker image to ${DOCKER_TAG}
+	docker push ${DOCKER_TAG}
+
 openshift-deploy: openshift-undeploy
 	@echo Deploying to OpenShift
 	oc create -f deploy/openshift/sws-configmap.yaml -n ${NAMESPACE}


### PR DESCRIPTION
Second part of #25 .

It adds a Makefile target called `docker-push` which push the local docker image to docker hub.
Docker image pushed is defined by the environment variables: `DOCKER_NAME`:`DOCKER_VERSION`

@jmazzitelli actually code is yours from comment in #25, haha :man_dancing: 