### PR TITLE
don't do extra steps in build so things are faster in the normal case

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ env:
 
 script:
   - if [ ! -z "$(gofmt -s -l ${GO_FILES})" ]; then echo "These files need to be formatted:" "$(gofmt -s -l ${GO_FILES})"; exit 1; fi # Gofmt Linter
-  - make test
+  - make clean build test
 
 # Push the docker images to docker hub
 # If a tag build, use the tag as docker version; otherwise, use branch name as docker version (where master==latest)
@@ -42,7 +42,6 @@ after_success:
 - export DOCKER_USER=$(if [ "$DOCKER_USER" == "" ]; then echo "unknown"; else echo $DOCKER_USER ; fi)
 - export DOCKER_PASS=$(if [ "$DOCKER_PASS" == "" ]; then echo "unknown"; else echo $DOCKER_PASS ; fi)
 - echo DOCKER_VERSION=$DOCKER_VERSION
-- make build
 - docker login -u "$DOCKER_USER" -p "$DOCKER_PASS"
 - make docker
 - docker push jmazzitelli/sws

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ git-init:
 	@echo Setting Git Hooks
 	cp hack/hooks/* .git/hooks
 
-build:  clean format
+build:
 	@echo Building...
 	${GO_BUILD_ENVVARS} go build \
 		-o ${GOPATH}/bin/sws -ldflags "-X main.version=${VERSION} -X main.commitHash=${COMMIT_HASH}"


### PR DESCRIPTION
I propose we do not do anything extra in the build target. I'm removing both clean and format as dependent targets on build for the following reasons:

1) format - we now have a pre-commit hook that will format the files for you on commit. Thus, there is no need to always format on build which is inefficient. The developer has options here - he can set up his IDE to always format on save (most devs do this) or they can "make format build" on the command line if they want to format during the build. By removing format dependency on build target, we don't force a format for EVERY build for EVERY developer.

2) clean - if we clean on every build, it deletes the UI code we installed in _output/npm. This has the detrimental effect of always forcing the user to download again (via npm install) the UI code which takes a long time (in some cases half a minute, and when the UI code gets larger, that time will only grow). Thus to avoid having to npm install everytime a dev wants to do a code-deploy-test cycle, we should not perform a clean on every build. If a developer wants to perform a clean build, the option is available by simply running "make clean build".

In short, this PR is to allow the build and test cycle to be faster for the normal case.

Note this PR also ensures travis only has to build once.