### PR TITLE
Fixing warnings / go vet

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -15,56 +15,60 @@ import (
 
 // Environment vars can define some default values.
 const (
-	ENV_IDENTITY_CERT_FILE        = "IDENTITY_CERT_FILE"
-	ENV_IDENTITY_PRIVATE_KEY_FILE = "IDENTITY_PRIVATE_KEY_FILE"
+	EnvIdentityCertFile       = "IDENTITY_CERT_FILE"
+	EnvIdentityPrivateKeyFile = "IDENTITY_PRIVATE_KEY_FILE"
 
-	ENV_PROMETHEUS_SERVICE_URL = "PROMETHEUS_SERVICE_URL"
+	EnvPrometheusServiceURL = "PROMETHEUS_SERVICE_URL"
 
-	ENV_SERVER_ADDRESS                       = "SERVER_ADDRESS"
-	ENV_SERVER_PORT                          = "SERVER_PORT"
-	ENV_SERVER_CREDENTIALS_USERNAME          = "SERVER_CREDENTIALS_USERNAME"
-	ENV_SERVER_CREDENTIALS_PASSWORD          = "SERVER_CREDENTIALS_PASSWORD"
-	ENV_SERVER_STATIC_CONTENT_ROOT_DIRECTORY = "SERVER_STATIC_CONTENT_ROOT_DIRECTORY"
+	EnvServerAddress                    = "SERVER_ADDRESS"
+	EnvServerPort                       = "SERVER_PORT"
+	EnvServerCredentialsUsername        = "SERVER_CREDENTIALS_USERNAME"
+	EnvServerCredentialsPassword        = "SERVER_CREDENTIALS_PASSWORD"
+	EnvServerStaticContentRootDirectory = "SERVER_STATIC_CONTENT_ROOT_DIRECTORY"
 )
 
 // Global configuration for the application.
 var configuration *Config
 
+// Server configuration
 type Server struct {
-	Address                    string               ",omitempty"
-	Port                       int                  ",omitempty"
-	Credentials                security.Credentials ",omitempty"
-	StaticContentRootDirectory string               "static_content_root_directory,omitempty"
+	Address                    string               `yaml:",omitempty"`
+	Port                       int                  `yaml:",omitempty"`
+	Credentials                security.Credentials `yaml:",omitempty"`
+	StaticContentRootDirectory string               `yaml:"static_content_root_directory,omitempty"`
 }
 
 // Config defines full YAML configuration.
 type Config struct {
-	Identity             security.Identity ",omitempty"
-	Server               Server            ",omitempty"
-	PrometheusServiceUrl string            "prometheus_service_url,omitempty"
+	Identity             security.Identity `yaml:",omitempty"`
+	Server               Server            `yaml:",omitempty"`
+	PrometheusServiceURL string            `yaml:"prometheus_service_url,omitempty"`
 }
 
+// NewConfig creates a default Config struct
 func NewConfig() (c *Config) {
 	c = new(Config)
 
-	c.Identity.CertFile = getDefaultString(ENV_IDENTITY_CERT_FILE, "")
-	c.Identity.PrivateKeyFile = getDefaultString(ENV_IDENTITY_PRIVATE_KEY_FILE, "")
+	c.Identity.CertFile = getDefaultString(EnvIdentityCertFile, "")
+	c.Identity.PrivateKeyFile = getDefaultString(EnvIdentityPrivateKeyFile, "")
 
-	c.Server.Address = strings.TrimSpace(getDefaultString(ENV_SERVER_ADDRESS, ""))
-	c.Server.Port = getDefaultInt(ENV_SERVER_PORT, 20000)
+	c.Server.Address = strings.TrimSpace(getDefaultString(EnvServerAddress, ""))
+	c.Server.Port = getDefaultInt(EnvServerPort, 20000)
 	c.Server.Credentials = security.Credentials{
-		Username: getDefaultString(ENV_SERVER_CREDENTIALS_USERNAME, ""),
-		Password: getDefaultString(ENV_SERVER_CREDENTIALS_PASSWORD, ""),
+		Username: getDefaultString(EnvServerCredentialsUsername, ""),
+		Password: getDefaultString(EnvServerCredentialsPassword, ""),
 	}
-	c.Server.StaticContentRootDirectory = strings.TrimSpace(getDefaultString(ENV_SERVER_STATIC_CONTENT_ROOT_DIRECTORY, "/static-files"))
-	c.PrometheusServiceUrl = strings.TrimSpace(getDefaultString(ENV_PROMETHEUS_SERVICE_URL, "http://prometheus:9090"))
+	c.Server.StaticContentRootDirectory = strings.TrimSpace(getDefaultString(EnvServerStaticContentRootDirectory, "/static-files"))
+	c.PrometheusServiceURL = strings.TrimSpace(getDefaultString(EnvPrometheusServiceURL, "http://prometheus:9090"))
 	return
 }
 
+// Get the global Config
 func Get() (conf *Config) {
 	return configuration
 }
 
+// Set the global Config
 func Set(conf *Config) {
 	configuration = conf
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -6,10 +6,10 @@ import (
 )
 
 func TestEnvVar(t *testing.T) {
-	defer os.Setenv(ENV_SERVER_ADDRESS, os.Getenv(ENV_SERVER_ADDRESS))
-	defer os.Setenv(ENV_SERVER_PORT, os.Getenv(ENV_SERVER_PORT))
-	os.Setenv(ENV_SERVER_ADDRESS, "test-address")
-	os.Setenv(ENV_SERVER_PORT, "12345")
+	defer os.Setenv(EnvServerAddress, os.Getenv(EnvServerAddress))
+	defer os.Setenv(EnvServerPort, os.Getenv(EnvServerPort))
+	os.Setenv(EnvServerAddress, "test-address")
+	os.Setenv(EnvServerPort, "12345")
 
 	conf := NewConfig()
 

--- a/config/security/config_security.go
+++ b/config/security/config_security.go
@@ -7,22 +7,22 @@ import (
 
 // Identity security details about a client.
 type Identity struct {
-	CertFile       string "cert_file"
-	PrivateKeyFile string "private_key_file"
+	CertFile       string `yaml:"cert_file"`
+	PrivateKeyFile string `yaml:"private_key_file"`
 }
 
 // Credentials provides information when needing to authenticate to remote endpoints.
 // Credentials are either a username/password or a bearer token, but not both.
 type Credentials struct {
-	Username string ",omitempty"
-	Password string ",omitempty"
-	Token    string ",omitempty"
+	Username string `yaml:",omitempty"`
+	Password string `yaml:",omitempty"`
+	Token    string `yaml:",omitempty"`
 }
 
-// SkipCertificateValidation will disable server certificate verification - the client
+// TLS options - SkipCertificateValidation will disable server certificate verification - the client
 // will accept any certificate presented by the server and any host name in that certificate.
 type TLS struct {
-	SkipCertificateValidation bool "skip_certificate_validation,omitempty"
+	SkipCertificateValidation bool `yaml:"skip_certificate_validation,omitempty"`
 }
 
 // ValidateCredentials makes sure that if username is provided, so is password (and vice versa)
@@ -30,21 +30,22 @@ type TLS struct {
 // It is valid to have nothing defined (no username, password, nor token).
 func (c *Credentials) ValidateCredentials() error {
 	if c.Username != "" && c.Password == "" {
-		return fmt.Errorf("A password must be provided if a username is set.")
+		return fmt.Errorf("A password must be provided if a username is set")
 	}
 
 	if c.Username == "" && c.Password != "" {
-		return fmt.Errorf("A username must be provided if a password is set.")
+		return fmt.Errorf("A username must be provided if a password is set")
 	}
 
 	if c.Username != "" && c.Token != "" {
-		return fmt.Errorf("Username/password cannot be specified if a token is specified also. Only Username/Password or Token can be set but not both.")
+		return fmt.Errorf("Username/password cannot be specified if a token is specified also. Only Username/Password or Token can be set but not both")
 	}
 
 	return nil
 }
 
-func (c *Credentials) GetHttpAuthHeader() (headerName string, headerValue string, err error) {
+// GetHTTPAuthHeader provides the authentication ehader name and value (can be empty), or an error
+func (c *Credentials) GetHTTPAuthHeader() (headerName string, headerValue string, err error) {
 	// if no credentials are provided, this is fine, we are just going to do an insecure request
 	if c == nil {
 		return "", "", nil

--- a/config/security/config_security_test.go
+++ b/config/security/config_security_test.go
@@ -12,7 +12,7 @@ func TestValidateCredentials(t *testing.T) {
 		t.Errorf("Empty credentials should be valid: %v", err)
 	}
 
-	if headerName, headerValue, err := creds.GetHttpAuthHeader(); err != nil {
+	if headerName, headerValue, err := creds.GetHTTPAuthHeader(); err != nil {
 		t.Errorf("Should not have received error: %v", err)
 	} else {
 		if headerName != "" || headerValue != "" {
@@ -28,7 +28,7 @@ func TestValidateCredentials(t *testing.T) {
 		t.Errorf("Username/Password credentials should be valid: %v", err)
 	}
 
-	if headerName, headerValue, err := creds.GetHttpAuthHeader(); err != nil {
+	if headerName, headerValue, err := creds.GetHTTPAuthHeader(); err != nil {
 		t.Errorf("Should not have received error: %v", err)
 	} else {
 		if headerName != "Authorization" || headerValue != "Basic dTpw" {
@@ -43,7 +43,7 @@ func TestValidateCredentials(t *testing.T) {
 		t.Errorf("Token credentials should be valid: %v", err)
 	}
 
-	if headerName, headerValue, err := creds.GetHttpAuthHeader(); err != nil {
+	if headerName, headerValue, err := creds.GetHTTPAuthHeader(); err != nil {
 		t.Errorf("Should not have received error: %v", err)
 	} else {
 		if headerName != "Authorization" || headerValue != "Bearer t" {

--- a/kubernetes/types.go
+++ b/kubernetes/types.go
@@ -53,7 +53,7 @@ type IstioObjectList interface {
 type ServiceDetails struct {
 	Service   *v1.Service   `json:"service"`
 	Endpoints *v1.Endpoints `json:"endpoints"`
-	Pods      []*v1.Pod     `json:pods`
+	Pods      []*v1.Pod     `json:"pods"`
 }
 
 // IstioDetails is a wrapper to group all Istio objects related to a Service.

--- a/prometheus/client.go
+++ b/prometheus/client.go
@@ -29,7 +29,7 @@ func NewClient() (*Client, error) {
 	if config.Get() == nil {
 		return nil, errors.New("config.Get() must be not null")
 	}
-	p8s, err := api.NewClient(api.Config{Address: config.Get().PrometheusServiceUrl})
+	p8s, err := api.NewClient(api.Config{Address: config.Get().PrometheusServiceURL})
 	if err != nil {
 		return nil, err
 	}

--- a/prometheus/client.go
+++ b/prometheus/client.go
@@ -14,7 +14,7 @@ import (
 	"github.com/swift-sunshine/swscore/config"
 )
 
-const istio_request_query = "istio_request_count{destination_service=~\"%s.%s.*\"}"
+const istioRequestQuery = "istio_request_count{destination_service=~\"%s.%s.*\"}"
 
 // Client for Prometheus API.
 // It hides the way we query Prometheus offering a layer with a high level defined API.
@@ -42,7 +42,7 @@ func NewClient() (*Client, error) {
 // Destination service is not included in the map as it is passed as argument.
 // It returns an error on any problem.
 func (in *Client) GetSourceServices(namespace string, servicename string) (map[string]string, error) {
-	query := fmt.Sprintf(istio_request_query, servicename, namespace)
+	query := fmt.Sprintf(istioRequestQuery, servicename, namespace)
 	api := v1.NewAPI(in.p8s)
 	result, err := api.Query(context.Background(), query, time.Now())
 	if err != nil {
@@ -67,6 +67,6 @@ func (in *Client) GetSourceServices(namespace string, servicename string) (map[s
 }
 
 // API returns the Prometheus V1 HTTP API for performing calls not supported natively by thi client
-func (in *Client) Api() v1.API {
+func (in *Client) API() v1.API {
 	return v1.NewAPI(in.p8s)
 }

--- a/routing/routes.go
+++ b/routing/routes.go
@@ -6,6 +6,7 @@ import (
 	"github.com/swift-sunshine/swscore/handlers"
 )
 
+// Route describes a single route
 type Route struct {
 	Name        string
 	Method      string
@@ -13,10 +14,12 @@ type Route struct {
 	HandlerFunc http.HandlerFunc
 }
 
+// Routes holds an array of Route
 type Routes struct {
 	Routes []Route
 }
 
+// NewRoutes creates and returns all the API routes
 func NewRoutes() (r *Routes) {
 	r = new(Routes)
 

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -74,22 +74,22 @@ func TestSecureComm(t *testing.T) {
 	conf.Server.Credentials.Username = authorizedUsername
 	conf.Server.Credentials.Password = authorizedPassword
 
-	serverUrl := fmt.Sprintf("https://%v", testServerHostPort)
-	consoleUrl := serverUrl + "/console"
-	apiUrl := serverUrl + "/api"
+	serverURL := fmt.Sprintf("https://%v", testServerHostPort)
+	consoleURL := serverURL + "/console"
+	apiURL := serverURL + "/api"
 
 	config.Set(conf)
 
 	server := NewServer()
 	server.Start()
-	t.Logf("Started test http server: %v", serverUrl)
+	t.Logf("Started test http server: %v", serverURL)
 	defer func() {
 		server.Stop()
-		t.Logf("Stopped test server: %v", serverUrl)
+		t.Logf("Stopped test server: %v", serverURL)
 	}()
 
 	// the client
-	httpConfig := HttpClientConfig{
+	httpConfig := httpClientConfig{
 		Identity: &security.Identity{
 			CertFile:       testClientCertFile,
 			PrivateKeyFile: testClientKeyFile,
@@ -98,7 +98,7 @@ func TestSecureComm(t *testing.T) {
 			InsecureSkipVerify: true,
 		},
 	}
-	httpClient, err := httpConfig.BuildHttpClient()
+	httpClient, err := httpConfig.buildHTTPClient()
 	if err != nil {
 		t.Fatalf("Failed to create http client")
 	}
@@ -119,35 +119,35 @@ func TestSecureComm(t *testing.T) {
 	noCredentials := &security.Credentials{}
 
 	// wait for our test http server to come up
-	checkHttpReady(httpClient, serverUrl)
+	checkHTTPReady(httpClient, serverURL)
 
 	// TEST WITH AN AUTHORIZED USER
 
-	if _, err = getRequestResults(t, httpClient, consoleUrl, basicCredentials); err != nil {
+	if _, err = getRequestResults(t, httpClient, consoleURL, basicCredentials); err != nil {
 		t.Fatalf("Failed: Basic Auth Console URL: %v", err)
 	}
 
-	if _, err = getRequestResults(t, httpClient, apiUrl, basicCredentials); err != nil {
+	if _, err = getRequestResults(t, httpClient, apiURL, basicCredentials); err != nil {
 		t.Fatalf("Failed: Basic Auth API URL: %v", err)
 	}
 
 	// TEST WITH AN INVALID USER
 
-	if _, err = getRequestResults(t, httpClient, consoleUrl, badBasicCredentials); err == nil {
+	if _, err = getRequestResults(t, httpClient, consoleURL, badBasicCredentials); err == nil {
 		t.Fatalf("Failed: Basic Auth Console URL should have failed")
 	}
 
-	if _, err = getRequestResults(t, httpClient, apiUrl, badBasicCredentials); err == nil {
+	if _, err = getRequestResults(t, httpClient, apiURL, badBasicCredentials); err == nil {
 		t.Fatalf("Failed: Basic Auth API URL should have failed")
 	}
 
 	// TEST WITH NO USER
 
-	if _, err = getRequestResults(t, httpClient, consoleUrl, noCredentials); err == nil {
+	if _, err = getRequestResults(t, httpClient, consoleURL, noCredentials); err == nil {
 		t.Fatalf("Failed: Basic Auth Console URL should have failed with no credentials: %v", err)
 	}
 
-	if _, err = getRequestResults(t, httpClient, apiUrl, noCredentials); err == nil {
+	if _, err = getRequestResults(t, httpClient, apiURL, noCredentials); err == nil {
 		t.Fatalf("Failed: Basic Auth API URL should have failed with with no credentials")
 	}
 }
@@ -158,7 +158,7 @@ func getRequestResults(t *testing.T, httpClient *http.Client, url string, creden
 		t.Fatal(err)
 		return "", err
 	}
-	if headerName, headerValue, err := credentials.GetHttpAuthHeader(); err != nil {
+	if headerName, headerValue, err := credentials.GetHTTPAuthHeader(); err != nil {
 		t.Fatal(err)
 		return "", err
 	} else if headerName != "" {
@@ -268,7 +268,7 @@ func getFreePort(host string) (int, error) {
 	return l.Addr().(*net.TCPAddr).Port, nil
 }
 
-func checkHttpReady(httpClient *http.Client, url string) {
+func checkHTTPReady(httpClient *http.Client, url string) {
 	for i := 0; i < 60; i++ {
 		if r, err := httpClient.Get(url); err == nil {
 			r.Body.Close()
@@ -280,14 +280,13 @@ func checkHttpReady(httpClient *http.Client, url string) {
 }
 
 // A generic HTTP client used to test accessing the server
-
-type HttpClientConfig struct {
+type httpClientConfig struct {
 	Identity      *security.Identity
 	TLSConfig     *tls.Config
 	HTTPTransport *http.Transport
 }
 
-func (conf *HttpClientConfig) BuildHttpClient() (*http.Client, error) {
+func (conf *httpClientConfig) buildHTTPClient() (*http.Client, error) {
 
 	// make our own copy of TLS config
 	tlsConfig := &tls.Config{}


### PR DESCRIPTION
- Vet: fix yaml tagging
(Go vet was reporting: struct field tag `,omitempty` not compatible with reflect.StructTag.Get: bad syntax for struct tag pair)
- Good practice: document all exported functions
- Good practice: mixedCaps https://golang.org/doc/effective_go.html#mixed-caps
- Good practice: use consistent case for initials
( https://github.com/golang/go/wiki/CodeReviewComments#initialisms )


PS: topic opened internally to discuss about code style