### PR TITLE
Service list endpoint

### DIFF
--- a/handlers/base.go
+++ b/handlers/base.go
@@ -1,0 +1,18 @@
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+func RespondWithJSON(w http.ResponseWriter, code int, payload interface{}) {
+	response, _ := json.Marshal(payload)
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(code)
+	w.Write(response)
+}
+
+func RespondWithError(w http.ResponseWriter, code int, message string) {
+	RespondWithJSON(w, code, map[string]string{"error": message})
+}

--- a/handlers/services.go
+++ b/handlers/services.go
@@ -1,0 +1,20 @@
+package handlers
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/swift-sunshine/swscore/log"
+	"github.com/swift-sunshine/swscore/models"
+)
+
+func ServiceList(w http.ResponseWriter, r *http.Request) {
+	var services [5]models.Service
+
+	for i := 0; i < len(services); i++ {
+		services[i] = models.Service{i, fmt.Sprintf("Name #%d", i), fmt.Sprintf("Namespace #'%d'", i)}
+	}
+
+	RespondWithJSON(w, 200, services)
+	log.Info("ROOT HANDLER CALLED!")
+}

--- a/models/service.go
+++ b/models/service.go
@@ -1,0 +1,7 @@
+package models
+
+type Service struct {
+	Id        int    `json:"id"`
+	Name      string `json:"name"`
+	Namespace string `json:"namespace"`
+}

--- a/routing/routes.go
+++ b/routing/routes.go
@@ -27,6 +27,12 @@ func NewRoutes() (r *Routes) {
 			"/api",
 			handlers.Root,
 		},
+		{
+			"ServiceList",
+			"GET",
+			"/api/services",
+			handlers.ServiceList,
+		},
 	}
 
 	return


### PR DESCRIPTION
Here is my proposal on how to approach the endpoints architecture. This is super simple.
(This is the first part of the #15 - It only contains work related to `/services` endpoint)

Here a couple of considerations I took:
- Handlers functions are grouped semanticaly
  - It means that in one handler file, it could be more than one handling function. But they must have to share similar concepts.
  - For a handler, I tend to think about MVC-Controller.
  - `/handlers/base` handler is the place where will leave all the common funcs for those handlers. e.g. rendering helpers
- I just create a `models` folder where main structs and logic can live into.
  - e.g. services, where I just defined a type Service and it might have some manipulation functions.
  - It might sound a little MVC-ish again. But I find that is a good starting point (open to hear about different approaches).

New features included here:
- `/api/services` - list of services for a namespace
  - this is dummy data at the moment.

Last but not least, let me show an screenshots of this Service List output:

![service-list-2](https://user-images.githubusercontent.com/613814/36264134-449265d8-126c-11e8-8fa8-0cb712726ffe.png)

This PR refers to the following JIRA: https://issues.jboss.org/browse/SWS-62
Upcoming work is comming for this SWS-62