### PR TITLE
Endpoints for Service List page

### DIFF
--- a/handlers/base.go
+++ b/handlers/base.go
@@ -1,0 +1,18 @@
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+func RespondWithJSON(w http.ResponseWriter, code int, payload interface{}) {
+	response, _ := json.Marshal(payload)
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(code)
+	w.Write(response)
+}
+
+func RespondWithError(w http.ResponseWriter, code int, message string) {
+	RespondWithJSON(w, code, map[string]string{"error": message})
+}

--- a/handlers/namespaces.go
+++ b/handlers/namespaces.go
@@ -1,0 +1,19 @@
+package handlers
+
+import (
+	"net/http"
+
+	"github.com/swift-sunshine/swscore/log"
+	"github.com/swift-sunshine/swscore/models"
+)
+
+func NamespaceList(w http.ResponseWriter, r *http.Request) {
+	namespaces, err := models.GetNamespaces()
+	if err != nil {
+		log.Error(err)
+		RespondWithError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+
+	RespondWithJSON(w, http.StatusOK, namespaces)
+}

--- a/handlers/root.go
+++ b/handlers/root.go
@@ -39,7 +39,8 @@ func demoFetchAllServicesAndPrintThem(w http.ResponseWriter) {
 		}
 		fmt.Fprintf(w, "Namespace: %s Services %v \n\n", namespace, services)
 
-		for _, service := range services {
+		for _, service_object := range services.Items {
+			service := service_object.Name
 			fmt.Fprintf(w, "Service Name: %s \n", service)
 			details, err := istioClient.GetServiceDetails(namespace, service)
 			if err != nil {

--- a/handlers/root.go
+++ b/handlers/root.go
@@ -31,7 +31,8 @@ func demoFetchAllServicesAndPrintThem(w http.ResponseWriter) {
 	}
 	fmt.Fprintf(w, "Namespaces: %v \n\n", namespaces)
 
-	for _, namespace := range namespaces {
+	for _, namespace_object := range namespaces.Items {
+		namespace := namespace_object.Name
 		services, err := istioClient.GetServices(namespace)
 		if err != nil {
 			log.Error(err)

--- a/handlers/services.go
+++ b/handlers/services.go
@@ -1,0 +1,23 @@
+package handlers
+
+import (
+	"net/http"
+
+	"github.com/gorilla/mux"
+	"github.com/swift-sunshine/swscore/log"
+	"github.com/swift-sunshine/swscore/models"
+)
+
+func ServiceList(w http.ResponseWriter, r *http.Request) {
+	params := mux.Vars(r)
+	namespace := models.Namespace{params["namespace"]}
+
+	services, err := models.GetServicesByNamespace(namespace.Name)
+	if err != nil {
+		log.Error(err)
+		RespondWithError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+
+	RespondWithJSON(w, http.StatusOK, models.ServiceList{namespace, services})
+}

--- a/kubernetes/client.go
+++ b/kubernetes/client.go
@@ -11,8 +11,6 @@ import (
 
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
-
-	"github.com/swift-sunshine/swscore/models"
 )
 
 const (
@@ -98,18 +96,16 @@ func NewClient() (*IstioClient, error) {
 	return &client, nil
 }
 
-// GetNamespaces returns a list of all namespaces/projects of the cluster.
+// GetNamespaces returns a list of all namespaces of the cluster.
+// It returns a list of all namespaces of the cluster.
 // It returns an error on any problem.
-func (in *IstioClient) GetNamespaces() ([]string, error) {
+func (in *IstioClient) GetNamespaces() (*v1.NamespaceList, error) {
 	namespaces, err := in.k8s.CoreV1().Namespaces().List(emptyListOptions)
 	if err != nil {
 		return nil, err
 	}
-	names := make([]string, len(namespaces.Items))
-	for i, namespace := range namespaces.Items {
-		names[i] = namespace.Name
-	}
-	return names, nil
+
+	return namespaces, nil
 }
 
 // GetServices returns a list of services for a given namespace.

--- a/kubernetes/client.go
+++ b/kubernetes/client.go
@@ -11,6 +11,8 @@ import (
 
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
+
+	"github.com/swift-sunshine/swscore/models"
 )
 
 const (
@@ -112,16 +114,13 @@ func (in *IstioClient) GetNamespaces() ([]string, error) {
 
 // GetServices returns a list of services for a given namespace.
 // It returns an error on any problem.
-func (in *IstioClient) GetServices(namespace string) ([]string, error) {
-	services, err := in.k8s.CoreV1().Services(namespace).List(emptyListOptions)
+func (in *IstioClient) GetServices(namespaceName string) (*v1.ServiceList, error) {
+	services, err := in.k8s.CoreV1().Services(namespaceName).List(emptyListOptions)
 	if err != nil {
 		return nil, err
 	}
-	names := make([]string, len(services.Items))
-	for i, service := range services.Items {
-		names[i] = service.Name
-	}
-	return names, nil
+
+	return services, nil
 }
 
 // GetServiceDetails returns full details for a given service, consisting on service description, endpoints and pods.

--- a/models/namespace.go
+++ b/models/namespace.go
@@ -1,0 +1,40 @@
+package models
+
+import (
+	"github.com/swift-sunshine/swscore/kubernetes"
+	"k8s.io/api/core/v1"
+)
+
+type Namespace struct {
+	Name string `json:"name"`
+}
+
+func GetNamespaces() ([]Namespace, error) {
+	istioClient, err := kubernetes.NewClient()
+	if err != nil {
+		return nil, err
+	}
+
+	services, err := istioClient.GetNamespaces()
+	if err != nil {
+		return nil, err
+	}
+
+	return CastNamespaceCollection(services), nil
+}
+
+func CastNamespaceCollection(nsl *v1.NamespaceList) []Namespace {
+	namespaces := make([]Namespace, len(nsl.Items))
+	for i, item := range nsl.Items {
+		namespaces[i] = CastNamespace(item)
+	}
+
+	return namespaces
+}
+
+func CastNamespace(ns v1.Namespace) Namespace {
+	namespace := Namespace{}
+	namespace.Name = ns.Name
+
+	return namespace
+}

--- a/models/service.go
+++ b/models/service.go
@@ -1,0 +1,45 @@
+package models
+
+import (
+	"github.com/swift-sunshine/swscore/kubernetes"
+	"k8s.io/api/core/v1"
+)
+
+type Service struct {
+	Name string `json:"name"`
+}
+
+type ServiceList struct {
+	Namespace Namespace `json:"namespace"`
+	Service   []Service `json:"services"`
+}
+
+func GetServicesByNamespace(namespaceName string) ([]Service, error) {
+	istioClient, err := kubernetes.NewClient()
+	if err != nil {
+		return nil, err
+	}
+
+	services, err := istioClient.GetServices(namespaceName)
+	if err != nil {
+		return nil, err
+	}
+
+	return CastServiceCollection(services), nil
+}
+
+func CastServiceCollection(sl *v1.ServiceList) []Service {
+	services := make([]Service, len(sl.Items))
+	for i, item := range sl.Items {
+		services[i] = CastService(item)
+	}
+
+	return services
+}
+
+func CastService(s v1.Service) Service {
+	service := Service{}
+	service.Name = s.Name
+
+	return service
+}

--- a/routing/routes.go
+++ b/routing/routes.go
@@ -30,6 +30,12 @@ func NewRoutes() (r *Routes) {
 			"/api",
 			handlers.Root,
 		},
+		{
+			"ServiceList",
+			"GET",
+			"/api/namespaces/{namespace}/services",
+			handlers.ServiceList,
+		},
 	}
 
 	return

--- a/routing/routes.go
+++ b/routing/routes.go
@@ -36,6 +36,12 @@ func NewRoutes() (r *Routes) {
 			"/api/namespaces/{namespace}/services",
 			handlers.ServiceList,
 		},
+		{
+			"NamespaceList",
+			"GET",
+			"/api/namespaces",
+			handlers.NamespaceList,
+		},
 	}
 
 	return


### PR DESCRIPTION
New features included here:
- `/api/namespaces` - listing all namespaces created within openshift
- `/api/namespaces/{namespace}/services` - list of services for a namespace named `{namespace}`

This PR addresses to [SWS-62](https://issues.jboss.org/browse/SWS-62) and is unblocking [SWS-63](https://issues.jboss.org/browse/SWS-63)  - showing those services in the UI - in progress by @lucasponce.

Let's see the output:
`/namespaces`
![namespaces-list](https://user-images.githubusercontent.com/613814/36420643-ff17252a-1635-11e8-9f00-bc2722ab3092.png)


`/namespaces/istio-system/services`
![services-list-w-namespace](https://user-images.githubusercontent.com/613814/36420636-fa80e1cc-1635-11e8-8c80-b7a192cac2f6.png)
