### PR TITLE
SWS-127: don't move the entire 300MB npm install into docker - just retain what we need

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,11 +77,16 @@ dep-update:
 # cloud targets - building images and deploying
 
 docker:
-	@echo Building Docker Image...
 	@mkdir -p _output/docker
 	@cp -r deploy/docker/* _output/docker
 	@cp ${GOPATH}/bin/sws _output/docker
-	@if [ ! -d "_output/docker/npm" ]; then npm --prefix _output/docker/npm -g install swsui; fi
+	@if [ ! -d "_output/docker/console" ]; then \
+		echo "Downloading console..." ; \
+		mkdir _output/docker/console ; \
+		curl $$(npm view swsui dist.tarball) \
+		| tar zxf - --strip-components=2 --directory _output/docker/console package/build ; \
+	fi
+	@echo Building Docker Image...
 	docker build -t ${DOCKER_TAG} _output/docker
 
 docker-push:

--- a/deploy/docker/Dockerfile
+++ b/deploy/docker/Dockerfile
@@ -7,6 +7,6 @@ ENV SWS_HOME=/opt/sws \
 
 COPY sws $SWS_HOME/
 
-ADD npm/lib/node_modules/swsui/build $SWS_HOME/console/
+ADD console $SWS_HOME/console/
 
 ENTRYPOINT ["/opt/sws/sws"]


### PR DESCRIPTION
@pilhuhn for you to review.

I found no way to tell npm install to only produce /build files.