### PR TITLE
SWS-119 Expose grafana URL

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -20,6 +20,7 @@ const (
 
 	EnvPrometheusServiceURL = "PROMETHEUS_SERVICE_URL"
 	EnvIstioIdentityDomain  = "ISTIO_IDENTITY_DOMAIN"
+	EnvGrafanaServiceURL    = "GRAFANA_SERVICE_URL"
 
 	EnvServerAddress                    = "SERVER_ADDRESS"
 	EnvServerPort                       = "SERVER_PORT"
@@ -47,6 +48,7 @@ type Config struct {
 	Server               Server            `yaml:",omitempty"`
 	PrometheusServiceURL string            `yaml:"prometheus_service_url,omitempty"`
 	IstioIdentityDomain  string            `yaml:"istio_identity_domain,omitempty"`
+	GrafanaServiceURL    string            `yaml:"grafana_service_url,omitempty"`
 }
 
 // NewConfig creates a default Config struct
@@ -66,6 +68,7 @@ func NewConfig() (c *Config) {
 	c.Server.CORSAllowAll = getDefaultBool(EnvServerCORSAllowAll, false)
 	c.PrometheusServiceURL = strings.TrimSpace(getDefaultString(EnvPrometheusServiceURL, "http://prometheus:9090"))
 	c.IstioIdentityDomain = strings.TrimSpace(getDefaultString(EnvIstioIdentityDomain, "svc.cluster.local"))
+	c.GrafanaServiceURL = strings.TrimSpace(getDefaultString(EnvGrafanaServiceURL, ""))
 	return
 }
 

--- a/handlers/grafana.go
+++ b/handlers/grafana.go
@@ -10,18 +10,19 @@ import (
 	"github.com/swift-sunshine/swscore/config"
 	"github.com/swift-sunshine/swscore/kubernetes"
 	"github.com/swift-sunshine/swscore/log"
+	"github.com/swift-sunshine/swscore/models"
 )
 
-// GetGrafanaURL provides the Grafana URL, first by checking if a config exists
+// GetGrafanaInfo provides the Grafana URL and other info, first by checking if a config exists
 // then (if not) by inspecting the Kubernetes Grafana service in namespace istio-system
-func GetGrafanaURL(w http.ResponseWriter, r *http.Request) {
-	url, code, err := getGrafanaURL(getGrafanaService)
+func GetGrafanaInfo(w http.ResponseWriter, r *http.Request) {
+	info, code, err := getGrafanaInfo(getGrafanaService)
 	if err != nil {
 		log.Error(err)
 		RespondWithError(w, code, err.Error())
 		return
 	}
-	RespondWithJSON(w, code, url)
+	RespondWithJSON(w, code, info)
 }
 
 func getGrafanaService() (*v1.ServiceSpec, error) {
@@ -36,23 +37,26 @@ func getGrafanaService() (*v1.ServiceSpec, error) {
 	return &details.Service.Spec, nil
 }
 
-// getGrafanaURL returns the URL (string), the HTTP status code (int) and eventually an error
-func getGrafanaURL(serviceSupplier func() (*v1.ServiceSpec, error)) (string, int, error) {
+// getGrafanaInfo returns the Grafana URL and other info, the HTTP status code (int) and eventually an error
+func getGrafanaInfo(serviceSupplier func() (*v1.ServiceSpec, error)) (*models.GrafanaInfo, int, error) {
+	suffix := config.Get().IstioIdentityDomain
 	configURL := config.Get().GrafanaServiceURL
 	if configURL != "" {
-		return configURL, http.StatusOK, nil
+		return &models.GrafanaInfo{
+			URL:             configURL,
+			VariablesSuffix: suffix}, http.StatusOK, nil
 	}
 
 	spec, err := serviceSupplier()
 	if err != nil {
-		return "", http.StatusInternalServerError, err
+		return nil, http.StatusInternalServerError, err
 	}
 
 	if spec.ClusterIP == "" || spec.ClusterIP == "None" {
-		return "", http.StatusNotFound, errors.New("Unable to find Grafana URL: clusterIP not defined on service 'grafana'")
+		return nil, http.StatusNotFound, errors.New("Unable to find Grafana URL: clusterIP not defined on service 'grafana'")
 	}
 	if len(spec.Ports) == 0 || spec.Ports[0].Port == 0 {
-		return "", http.StatusNotFound, errors.New("Unable to find Grafana URL: no port defined on service 'grafana'")
+		return nil, http.StatusNotFound, errors.New("Unable to find Grafana URL: no port defined on service 'grafana'")
 	}
 
 	if len(spec.Ports) > 1 {
@@ -61,5 +65,7 @@ func getGrafanaURL(serviceSupplier func() (*v1.ServiceSpec, error)) (string, int
 
 	// detect https?
 	url := fmt.Sprintf("http://%s:%d", spec.ClusterIP, spec.Ports[0].Port)
-	return url, http.StatusOK, nil
+	return &models.GrafanaInfo{
+		URL:             url,
+		VariablesSuffix: suffix}, http.StatusOK, nil
 }

--- a/handlers/grafana.go
+++ b/handlers/grafana.go
@@ -1,0 +1,65 @@
+package handlers
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+
+	"k8s.io/api/core/v1"
+
+	"github.com/swift-sunshine/swscore/config"
+	"github.com/swift-sunshine/swscore/kubernetes"
+	"github.com/swift-sunshine/swscore/log"
+)
+
+// GetGrafanaURL provides the Grafana URL, first by checking if a config exists
+// then (if not) by inspecting the Kubernetes Grafana service in namespace istio-system
+func GetGrafanaURL(w http.ResponseWriter, r *http.Request) {
+	url, code, err := getGrafanaURL(getGrafanaService)
+	if err != nil {
+		log.Error(err)
+		RespondWithError(w, code, err.Error())
+		return
+	}
+	RespondWithJSON(w, code, url)
+}
+
+func getGrafanaService() (*v1.ServiceSpec, error) {
+	client, err := kubernetes.NewClient()
+	if err != nil {
+		return nil, err
+	}
+	details, err := client.GetServiceDetails("istio-system", "grafana")
+	if err != nil {
+		return nil, err
+	}
+	return &details.Service.Spec, nil
+}
+
+// getGrafanaURL returns the URL (string), the HTTP status code (int) and eventually an error
+func getGrafanaURL(serviceSupplier func() (*v1.ServiceSpec, error)) (string, int, error) {
+	configURL := config.Get().GrafanaServiceURL
+	if configURL != "" {
+		return configURL, http.StatusOK, nil
+	}
+
+	spec, err := serviceSupplier()
+	if err != nil {
+		return "", http.StatusInternalServerError, err
+	}
+
+	if spec.ClusterIP == "" || spec.ClusterIP == "None" {
+		return "", http.StatusNotFound, errors.New("Unable to find Grafana URL: clusterIP not defined on service 'grafana'")
+	}
+	if len(spec.Ports) == 0 || spec.Ports[0].Port == 0 {
+		return "", http.StatusNotFound, errors.New("Unable to find Grafana URL: no port defined on service 'grafana'")
+	}
+
+	if len(spec.Ports) > 1 {
+		log.Warning("Several ports found for service 'grafana', only the first will be used")
+	}
+
+	// detect https?
+	url := fmt.Sprintf("http://%s:%d", spec.ClusterIP, spec.Ports[0].Port)
+	return url, http.StatusOK, nil
+}

--- a/handlers/grafana_test.go
+++ b/handlers/grafana_test.go
@@ -1,0 +1,64 @@
+package handlers
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/swift-sunshine/swscore/config"
+	"k8s.io/api/core/v1"
+)
+
+func TestGetGrafanaURLFromService(t *testing.T) {
+	conf := config.NewConfig()
+	config.Set(conf)
+	url, code, err := getGrafanaURL(func() (*v1.ServiceSpec, error) {
+		return &v1.ServiceSpec{
+			ClusterIP: "fromservice",
+			Ports: []v1.ServicePort{
+				v1.ServicePort{Port: 3000}}}, nil
+	})
+	assert.Nil(t, err)
+	assert.Equal(t, http.StatusOK, code)
+	assert.Equal(t, "http://fromservice:3000", url)
+}
+
+func TestGetGrafanaURLFromConfig(t *testing.T) {
+	conf := config.NewConfig()
+	conf.GrafanaServiceURL = "http://fromconfig:3001"
+	config.Set(conf)
+	url, code, err := getGrafanaURL(func() (*v1.ServiceSpec, error) {
+		return &v1.ServiceSpec{
+			ClusterIP: "fromservice",
+			Ports: []v1.ServicePort{
+				v1.ServicePort{Port: 3000}}}, nil
+	})
+	assert.Nil(t, err)
+	assert.Equal(t, http.StatusOK, code)
+	assert.Equal(t, "http://fromconfig:3001", url)
+}
+
+func TestGetGrafanaURLNoPort(t *testing.T) {
+	conf := config.NewConfig()
+	config.Set(conf)
+	_, code, err := getGrafanaURL(func() (*v1.ServiceSpec, error) {
+		return &v1.ServiceSpec{
+			ClusterIP: "10.0.0.1",
+			Ports:     []v1.ServicePort{}}, nil
+	})
+	assert.NotNil(t, err)
+	assert.Equal(t, http.StatusNotFound, code)
+}
+
+func TestGetGrafanaURLNoClusterIP(t *testing.T) {
+	conf := config.NewConfig()
+	config.Set(conf)
+	_, code, err := getGrafanaURL(func() (*v1.ServiceSpec, error) {
+		return &v1.ServiceSpec{
+			ClusterIP: "",
+			Ports: []v1.ServicePort{
+				v1.ServicePort{Port: 3000}}}, nil
+	})
+	assert.NotNil(t, err)
+	assert.Equal(t, http.StatusNotFound, code)
+}

--- a/handlers/grafana_test.go
+++ b/handlers/grafana_test.go
@@ -12,7 +12,7 @@ import (
 func TestGetGrafanaURLFromService(t *testing.T) {
 	conf := config.NewConfig()
 	config.Set(conf)
-	url, code, err := getGrafanaURL(func() (*v1.ServiceSpec, error) {
+	info, code, err := getGrafanaInfo(func() (*v1.ServiceSpec, error) {
 		return &v1.ServiceSpec{
 			ClusterIP: "fromservice",
 			Ports: []v1.ServicePort{
@@ -20,14 +20,15 @@ func TestGetGrafanaURLFromService(t *testing.T) {
 	})
 	assert.Nil(t, err)
 	assert.Equal(t, http.StatusOK, code)
-	assert.Equal(t, "http://fromservice:3000", url)
+	assert.Equal(t, "http://fromservice:3000", info.URL)
+	assert.Equal(t, "svc.cluster.local", info.VariablesSuffix)
 }
 
 func TestGetGrafanaURLFromConfig(t *testing.T) {
 	conf := config.NewConfig()
 	conf.GrafanaServiceURL = "http://fromconfig:3001"
 	config.Set(conf)
-	url, code, err := getGrafanaURL(func() (*v1.ServiceSpec, error) {
+	info, code, err := getGrafanaInfo(func() (*v1.ServiceSpec, error) {
 		return &v1.ServiceSpec{
 			ClusterIP: "fromservice",
 			Ports: []v1.ServicePort{
@@ -35,13 +36,14 @@ func TestGetGrafanaURLFromConfig(t *testing.T) {
 	})
 	assert.Nil(t, err)
 	assert.Equal(t, http.StatusOK, code)
-	assert.Equal(t, "http://fromconfig:3001", url)
+	assert.Equal(t, "http://fromconfig:3001", info.URL)
+	assert.Equal(t, "svc.cluster.local", info.VariablesSuffix)
 }
 
 func TestGetGrafanaURLNoPort(t *testing.T) {
 	conf := config.NewConfig()
 	config.Set(conf)
-	_, code, err := getGrafanaURL(func() (*v1.ServiceSpec, error) {
+	_, code, err := getGrafanaInfo(func() (*v1.ServiceSpec, error) {
 		return &v1.ServiceSpec{
 			ClusterIP: "10.0.0.1",
 			Ports:     []v1.ServicePort{}}, nil
@@ -53,7 +55,7 @@ func TestGetGrafanaURLNoPort(t *testing.T) {
 func TestGetGrafanaURLNoClusterIP(t *testing.T) {
 	conf := config.NewConfig()
 	config.Set(conf)
-	_, code, err := getGrafanaURL(func() (*v1.ServiceSpec, error) {
+	_, code, err := getGrafanaInfo(func() (*v1.ServiceSpec, error) {
 		return &v1.ServiceSpec{
 			ClusterIP: "",
 			Ports: []v1.ServicePort{

--- a/models/grafana_info.go
+++ b/models/grafana_info.go
@@ -1,0 +1,7 @@
+package models
+
+// GrafanaInfo provides information to access Grafana dashboards
+type GrafanaInfo struct {
+	URL             string `json:"url"`
+	VariablesSuffix string `json:"variablesSuffix"`
+}

--- a/routing/routes.go
+++ b/routing/routes.go
@@ -80,6 +80,12 @@ func NewRoutes() (r *Routes) {
 			"/api/namespaces/{namespace}/services/{service}/graphs",
 			handlers.GraphService,
 		},
+		{
+			"GrafanaURL",
+			"GET",
+			"/api/grafana",
+			handlers.GetGrafanaURL,
+		},
 	}
 
 	return

--- a/routing/routes.go
+++ b/routing/routes.go
@@ -84,7 +84,7 @@ func NewRoutes() (r *Routes) {
 			"GrafanaURL",
 			"GET",
 			"/api/grafana",
-			handlers.GetGrafanaURL,
+			handlers.GetGrafanaInfo,
 		},
 	}
 


### PR DESCRIPTION
Determine Grafana URL:

- If it's in the config, then use that one
- Else try to guess using k8s API

This URL will be used on the front-end to display a link to Grafana.

This function is exposed on endpoint `/api/grafana`