### PR TITLE
SWS-67 Handling errors (404,500) for Service Details endpoint

### DIFF
--- a/models/service.go
+++ b/models/service.go
@@ -52,11 +52,20 @@ func GetServiceDetails(namespaceName, serviceName string) (*Service, error) {
 	service := Service{}
 	service.Name = serviceName
 	service.Namespace = Namespace{namespaceName}
-	service.setKubernetesDetails(istioClient)
-	service.setIstioDetails(istioClient)
-	service.setPrometheusDetails()
 
-	return &service, nil
+	if err = service.setKubernetesDetails(istioClient); err != nil {
+		return nil, err
+	}
+
+	if err = service.setIstioDetails(istioClient); err != nil {
+		return nil, err
+	}
+
+	if err = service.setPrometheusDetails(); err != nil {
+		return nil, err
+	}
+
+	return &service, err
 }
 
 func CastServiceOverviewCollection(sl *v1.ServiceList) []ServiceOverview {
@@ -76,7 +85,6 @@ func CastServiceOverview(s v1.Service) ServiceOverview {
 }
 
 func (s *Service) setKubernetesDetails(c *kubernetes.IstioClient) error {
-
 	serviceDetails, err := c.GetServiceDetails(s.Namespace.Name, s.Name)
 	if err != nil {
 		return err


### PR DESCRIPTION
This PR adds error handling to Service Details endpoint. In particular, it adds the 404 error instead of only responding with 500 errors.

![service-not-found](https://user-images.githubusercontent.com/613814/36784908-5757a786-1c81-11e8-930c-af6d04246482.png)

This is connected to [SWS-67](https://issues.jboss.org/browse/SWS-67)