### PR TITLE
SWS-190: Fix duplicated source services and routerules

### DIFF
--- a/kubernetes/client.go
+++ b/kubernetes/client.go
@@ -167,7 +167,7 @@ func (in *IstioClient) GetIstioDetails(namespace string, serviceName string) (*I
 		if destination, ok := rule.Spec["destination"]; ok {
 			dest := destination.(map[string]interface{})
 			if dest["name"] == serviceName {
-				routerRules = append(routerRules, &rule)
+				routerRules = append(routerRules, rule.DeepCopy())
 			}
 		}
 	}

--- a/prometheus/client.go
+++ b/prometheus/client.go
@@ -65,7 +65,16 @@ func (in *Client) GetSourceServices(namespace string, servicename string) (map[s
 			}
 			source := fmt.Sprintf("%s/%s", sourceService, metric["source_version"])
 			if arr, ok := routes[index]; ok {
-				routes[index] = append(arr, source)
+				found := false
+				for _, s := range arr {
+					if s == source {
+						found = true
+						break
+					}
+				}
+				if !found {
+					routes[index] = append(arr, source)
+				}
 			} else {
 				routes[index] = []string{source}
 			}

--- a/prometheus/client_test.go
+++ b/prometheus/client_test.go
@@ -52,11 +52,20 @@ func setupMocked() (*Client, *promAPIMock, error) {
 }
 
 func TestGetSourceServices(t *testing.T) {
-	rqCustV1 := model.Metric{
+	rqCustV1C200 := model.Metric{
 		"__name__":            "istio_request_count",
 		"instance":            "172.17.0.6:42422",
 		"job":                 "istio-mesh",
 		"response_code":       "200",
+		"source_service":      "customer.istio-system.svc.cluster.local",
+		"source_version":      "v1",
+		"destination_service": "productpage.istio-system.svc.cluster.local",
+		"destination_version": "v1"}
+	rqCustV1C404 := model.Metric{
+		"__name__":            "istio_request_count",
+		"instance":            "172.17.0.6:42422",
+		"job":                 "istio-mesh",
+		"response_code":       "404",
 		"source_service":      "customer.istio-system.svc.cluster.local",
 		"source_version":      "v1",
 		"destination_service": "productpage.istio-system.svc.cluster.local",
@@ -81,7 +90,10 @@ func TestGetSourceServices(t *testing.T) {
 		"destination_version": "v2"}
 	vector := model.Vector{
 		&model.Sample{
-			Metric: rqCustV1,
+			Metric: rqCustV1C200,
+			Value:  4},
+		&model.Sample{
+			Metric: rqCustV1C404,
 			Value:  4},
 		&model.Sample{
 			Metric: rqCustV2,


### PR DESCRIPTION
This is a bug fix, tests have been updated for prometheus client.
Kubernetes client tests will be added once https://github.com/swift-sunshine/swscore/pull/76 work is consolidated.
So I will add these tests later, but for Sprint 1, I guess we can fix this one.