### PR TITLE
SWS-191 Add RouteRule.MATCH attribute into Service details endpoint

### DIFF
--- a/models/route_rules.go
+++ b/models/route_rules.go
@@ -9,6 +9,7 @@ type RouteRule struct {
 	Destination interface{} `json:"destination"`
 	Precedence  interface{} `json:"precedence"`
 	Route       interface{} `json:"route"`
+	Match       interface{} `json:"match"`
 }
 
 func (rules *RouteRules) Parse(routeRules []*kubernetes.RouteRule) {
@@ -23,4 +24,5 @@ func (rule *RouteRule) Parse(routeRule *kubernetes.RouteRule) {
 	rule.Destination = routeRule.Spec["destination"]
 	rule.Precedence = routeRule.Spec["precedence"]
 	rule.Route = routeRule.Spec["route"]
+	rule.Match = routeRule.Spec["match"]
 }


### PR DESCRIPTION
@lucasponce realized service endpoint missed RouteRule.MATCH fields from Istio Route Rules.

![route-rules-match](https://user-images.githubusercontent.com/613814/36850353-cf8ff5e2-1d66-11e8-97fc-e8531fd94063.png)
