### PR TITLE
SWS-192 Add RouteRule.Name to Service Details endpoint

### DIFF
--- a/models/route_rules.go
+++ b/models/route_rules.go
@@ -6,6 +6,7 @@ import (
 
 type RouteRules []RouteRule
 type RouteRule struct {
+	Name        string      `json:"name"`
 	Destination interface{} `json:"destination"`
 	Precedence  interface{} `json:"precedence"`
 	Route       interface{} `json:"route"`
@@ -21,6 +22,7 @@ func (rules *RouteRules) Parse(routeRules []*kubernetes.RouteRule) {
 }
 
 func (rule *RouteRule) Parse(routeRule *kubernetes.RouteRule) {
+	rule.Name = routeRule.ObjectMeta.Name
 	rule.Destination = routeRule.Spec["destination"]
 	rule.Precedence = routeRule.Spec["precedence"]
 	rule.Route = routeRule.Spec["route"]


### PR DESCRIPTION
Fine tunning Istio Route Rules view within Service Details.
This work addresses [SWS-192](https://issues.jboss.org/browse/SWS-192)

![route-rules-name](https://user-images.githubusercontent.com/613814/36851308-3da0462a-1d69-11e8-9e9d-840af5ff663c.png)

@lucasponce here it goes :)