### PR TITLE
SWS-171 more configurable Grafana links

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -285,6 +285,62 @@ server:
 prometheus_service_url: VALUE
 ----
 
+|`GRAFANA_DISPLAY_LINK`
+|When true, a link to Grafana will be displayed for more metrics.
+[source,yaml]
+----
+grafana:
+  display_link: (true\|false)
+----
+
+|`GRAFANA_URL`
+|The URL to the Grafana server. When not set, the URL may be automatically detected from OpenShift or Kubernetes API.
+[source,yaml]
+----
+grafana:
+  url: VALUE
+----
+
+|`GRAFANA_SERVICE_NAMESPACE`
+|The Kubernetes namespace that holds the Grafana service. This configuration is ignored if `GRAFANA_URL` is set. Default is `istio-system`.
+[source,yaml]
+----
+grafana:
+  service_namespace: VALUE
+----
+
+|`GRAFANA_SERVICE`
+|The OpenShift route name or the Kubernetes service name for Grafana. This configuration is ignored if `GRAFANA_URL` is set. Default is `grafana`.
+[source,yaml]
+----
+grafana:
+  service: VALUE
+----
+
+|`GRAFANA_DASHBOARD`
+|The name of the Grafana dashboard used as a landing page. Default is `istio-dashboard`.
+[source,yaml]
+----
+grafana:
+  dashboard: VALUE
+----
+
+|`GRAFANA_VAR_SERVICE_SOURCE`
+|The name of the Grafana variable that controls service sources, as defined in the configured `GRAFANA_DASHBOARD`. Default is `var-source`.
+[source,yaml]
+----
+grafana:
+  var_service_source: VALUE
+----
+
+|`GRAFANA_VAR_SERVICE_DEST`
+|The name of the Grafana variable that controls service destinations, as defined in the configured `GRAFANA_DASHBOARD`. Default is `var-http_destination`.
+[source,yaml]
+----
+grafana:
+  var_service_dest: VALUE
+----
+
 |===
 
 == Additional Notes
@@ -310,4 +366,3 @@ If you git cloned the swsui repository in directory `/my/git/repo` and have buil
 ----
 CONSOLE_VERSION=local CONSOLE_LOCAL_DIR=/my/git/repo make docker
 ----
-

--- a/config/config.go
+++ b/config/config.go
@@ -20,7 +20,6 @@ const (
 
 	EnvPrometheusServiceURL = "PROMETHEUS_SERVICE_URL"
 	EnvIstioIdentityDomain  = "ISTIO_IDENTITY_DOMAIN"
-	EnvGrafanaServiceURL    = "GRAFANA_SERVICE_URL"
 
 	EnvServerAddress                    = "SERVER_ADDRESS"
 	EnvServerPort                       = "SERVER_PORT"
@@ -28,6 +27,14 @@ const (
 	EnvServerCredentialsPassword        = "SERVER_CREDENTIALS_PASSWORD"
 	EnvServerStaticContentRootDirectory = "SERVER_STATIC_CONTENT_ROOT_DIRECTORY"
 	EnvServerCORSAllowAll               = "SERVER_CORS_ALLOW_ALL"
+
+	EnvGrafanaDisplayLink      = "GRAFANA_DISPLAY_LINK"
+	EnvGrafanaURL              = "GRAFANA_URL"
+	EnvGrafanaServiceNamespace = "GRAFANA_SERVICE_NAMESPACE"
+	EnvGrafanaService          = "GRAFANA_SERVICE"
+	EnvGrafanaDashboard        = "GRAFANA_DASHBOARD"
+	EnvGrafanaVarServiceSource = "GRAFANA_VAR_SERVICE_SOURCE"
+	EnvGrafanaVarServiceDest   = "GRAFANA_VAR_SERVICE_DEST"
 )
 
 // Global configuration for the application.
@@ -42,13 +49,24 @@ type Server struct {
 	CORSAllowAll               bool                 `yaml:"cors_allow_all,omitempty"`
 }
 
+// GrafanaConfig describes configuration used for Grafana links
+type GrafanaConfig struct {
+	DisplayLink      bool   `yaml:"display_link"`
+	URL              string `yaml:"url"`
+	ServiceNamespace string `yaml:"service_namespace"`
+	Service          string `yaml:"service"`
+	Dashboard        string `yaml:"dashboard"`
+	VarServiceSource string `yaml:"var_service_source"`
+	VarServiceDest   string `yaml:"var_service_dest"`
+}
+
 // Config defines full YAML configuration.
 type Config struct {
 	Identity             security.Identity `yaml:",omitempty"`
 	Server               Server            `yaml:",omitempty"`
 	PrometheusServiceURL string            `yaml:"prometheus_service_url,omitempty"`
 	IstioIdentityDomain  string            `yaml:"istio_identity_domain,omitempty"`
-	GrafanaServiceURL    string            `yaml:"grafana_service_url,omitempty"`
+	Grafana              GrafanaConfig     `yaml:"grafana,omitempty"`
 }
 
 // NewConfig creates a default Config struct
@@ -68,7 +86,14 @@ func NewConfig() (c *Config) {
 	c.Server.CORSAllowAll = getDefaultBool(EnvServerCORSAllowAll, false)
 	c.PrometheusServiceURL = strings.TrimSpace(getDefaultString(EnvPrometheusServiceURL, "http://prometheus:9090"))
 	c.IstioIdentityDomain = strings.TrimSpace(getDefaultString(EnvIstioIdentityDomain, "svc.cluster.local"))
-	c.GrafanaServiceURL = strings.TrimSpace(getDefaultString(EnvGrafanaServiceURL, ""))
+
+	c.Grafana.DisplayLink = getDefaultBool(EnvGrafanaDisplayLink, true)
+	c.Grafana.URL = strings.TrimSpace(getDefaultString(EnvGrafanaURL, ""))
+	c.Grafana.ServiceNamespace = strings.TrimSpace(getDefaultString(EnvGrafanaServiceNamespace, "istio-system"))
+	c.Grafana.Service = strings.TrimSpace(getDefaultString(EnvGrafanaService, "grafana"))
+	c.Grafana.Dashboard = strings.TrimSpace(getDefaultString(EnvGrafanaDashboard, "istio-dashboard"))
+	c.Grafana.VarServiceSource = strings.TrimSpace(getDefaultString(EnvGrafanaVarServiceSource, "var-source"))
+	c.Grafana.VarServiceDest = strings.TrimSpace(getDefaultString(EnvGrafanaVarServiceDest, "var-http_destination"))
 	return
 }
 

--- a/deploy/openshift/sws.yaml
+++ b/deploy/openshift/sws.yaml
@@ -97,6 +97,12 @@ rules:
   - get
   - list
   - watch
+- apiGroups: ["route.openshift.io"]
+  attributeRestrictions: null
+  resources:
+  - routes
+  verbs:
+  - get
 - apiGroups: ["config.istio.io"]
   attributeRestrictions: null
   resources:

--- a/handlers/grafana.go
+++ b/handlers/grafana.go
@@ -13,10 +13,13 @@ import (
 	"github.com/swift-sunshine/swscore/models"
 )
 
+type osRouteSupplier func(string, string) (string, error)
+type serviceSupplier func(string, string) (*v1.ServiceSpec, error)
+
 // GetGrafanaInfo provides the Grafana URL and other info, first by checking if a config exists
 // then (if not) by inspecting the Kubernetes Grafana service in namespace istio-system
 func GetGrafanaInfo(w http.ResponseWriter, r *http.Request) {
-	info, code, err := getGrafanaInfo(getGrafanaService)
+	info, code, err := getGrafanaInfo(getOpenshiftRouteURL, getGrafanaService)
 	if err != nil {
 		log.Error(err)
 		RespondWithError(w, code, err.Error())
@@ -25,12 +28,20 @@ func GetGrafanaInfo(w http.ResponseWriter, r *http.Request) {
 	RespondWithJSON(w, code, info)
 }
 
-func getGrafanaService() (*v1.ServiceSpec, error) {
+func getOpenshiftRouteURL(namespace string, name string) (string, error) {
+	client, err := kubernetes.NewOSRouteClient()
+	if err != nil {
+		return "", err
+	}
+	return client.GetRoute(namespace, name)
+}
+
+func getGrafanaService(namespace string, service string) (*v1.ServiceSpec, error) {
 	client, err := kubernetes.NewClient()
 	if err != nil {
 		return nil, err
 	}
-	details, err := client.GetServiceDetails("istio-system", "grafana")
+	details, err := client.GetServiceDetails(namespace, service)
 	if err != nil {
 		return nil, err
 	}
@@ -38,34 +49,51 @@ func getGrafanaService() (*v1.ServiceSpec, error) {
 }
 
 // getGrafanaInfo returns the Grafana URL and other info, the HTTP status code (int) and eventually an error
-func getGrafanaInfo(serviceSupplier func() (*v1.ServiceSpec, error)) (*models.GrafanaInfo, int, error) {
+func getGrafanaInfo(osRouteSupplier osRouteSupplier, serviceSupplier serviceSupplier) (*models.GrafanaInfo, int, error) {
 	suffix := config.Get().IstioIdentityDomain
-	configURL := config.Get().GrafanaServiceURL
-	if configURL != "" {
-		return &models.GrafanaInfo{
-			URL:             configURL,
-			VariablesSuffix: suffix}, http.StatusOK, nil
+	grafanaConfig := config.Get().Grafana
+	if !grafanaConfig.DisplayLink {
+		return nil, http.StatusNoContent, nil
+	}
+	grafanaInfo := models.GrafanaInfo{
+		URL:              grafanaConfig.URL,
+		VariablesSuffix:  suffix,
+		Dashboard:        grafanaConfig.Dashboard,
+		VarServiceSource: grafanaConfig.VarServiceSource,
+		VarServiceDest:   grafanaConfig.VarServiceDest}
+	if grafanaInfo.URL != "" {
+		return &grafanaInfo, http.StatusOK, nil
 	}
 
-	spec, err := serviceSupplier()
+	url, err := osRouteSupplier(grafanaConfig.ServiceNamespace, grafanaConfig.Service)
+	if err == nil {
+		grafanaInfo.URL = url
+		return &grafanaInfo, http.StatusOK, nil
+	}
+	// Else on error, silently continue. Might not be running on OpenShift.
+
+	spec, err := serviceSupplier(grafanaConfig.ServiceNamespace, grafanaConfig.Service)
 	if err != nil {
 		return nil, http.StatusInternalServerError, err
 	}
 
-	if spec.ClusterIP == "" || spec.ClusterIP == "None" {
-		return nil, http.StatusNotFound, errors.New("Unable to find Grafana URL: clusterIP not defined on service 'grafana'")
+	if len(spec.ExternalIPs) == 0 {
+		return nil, http.StatusNotFound, errors.New("Unable to find Grafana URL: no route defined. ExternalIPs not defined on service 'grafana'")
 	}
-	if len(spec.Ports) == 0 || spec.Ports[0].Port == 0 {
-		return nil, http.StatusNotFound, errors.New("Unable to find Grafana URL: no port defined on service 'grafana'")
-	}
+	var port int32
+	port = 80
 
-	if len(spec.Ports) > 1 {
-		log.Warning("Several ports found for service 'grafana', only the first will be used")
+	if len(spec.ExternalIPs) > 1 {
+		log.Warning("Several IPs found for service 'grafana', only the first will be used")
+	}
+	if len(spec.Ports) > 0 {
+		port = spec.Ports[0].Port
+		if len(spec.Ports) > 1 {
+			log.Warning("Several ports found for service 'grafana', only the first will be used")
+		}
 	}
 
 	// detect https?
-	url := fmt.Sprintf("http://%s:%d", spec.ClusterIP, spec.Ports[0].Port)
-	return &models.GrafanaInfo{
-		URL:             url,
-		VariablesSuffix: suffix}, http.StatusOK, nil
+	grafanaInfo.URL = fmt.Sprintf("http://%s:%d", spec.ExternalIPs[0], port)
+	return &grafanaInfo, http.StatusOK, nil
 }

--- a/kubernetes/client.go
+++ b/kubernetes/client.go
@@ -60,10 +60,10 @@ func NewClient() (*IstioClient, error) {
 	types := runtime.NewScheme()
 	schemeBuilder := runtime.NewSchemeBuilder(
 		func(scheme *runtime.Scheme) error {
-			for _, kind := range KnownTypes {
-				scheme.AddKnownTypes(IstioGroupVersion, kind.object, kind.collection)
+			for _, kind := range istioKnownTypes {
+				scheme.AddKnownTypes(istioGroupVersion, kind.object, kind.collection)
 			}
-			meta_v1.AddToGroupVersion(scheme, IstioGroupVersion)
+			meta_v1.AddToGroupVersion(scheme, istioGroupVersion)
 			return nil
 		})
 
@@ -77,7 +77,7 @@ func NewClient() (*IstioClient, error) {
 		Host:    config.Host,
 		APIPath: "/apis",
 		ContentConfig: rest.ContentConfig{
-			GroupVersion:         &IstioGroupVersion,
+			GroupVersion:         &istioGroupVersion,
 			NegotiatedSerializer: serializer.DirectCodecFactory{CodecFactory: serializer.NewCodecFactory(types)},
 			ContentType:          runtime.ContentTypeJSON,
 		},

--- a/kubernetes/os_route_client.go
+++ b/kubernetes/os_route_client.go
@@ -1,0 +1,81 @@
+package kubernetes
+
+import (
+	"encoding/json"
+	"errors"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+
+	"k8s.io/client-go/rest"
+)
+
+// OSRouteClient is the client struct for OpenShift Routes API over Kubernetes
+// It hides the way it queries each API
+type OSRouteClient struct {
+	client *rest.RESTClient
+}
+
+// NewOSRouteClient creates a new client able to fetch OpenShift Routes API.
+func NewOSRouteClient() (*OSRouteClient, error) {
+	config, err := rest.InClusterConfig()
+	if err != nil {
+		return nil, err
+	}
+
+	types := runtime.NewScheme()
+	schemeBuilder := runtime.NewSchemeBuilder(
+		func(scheme *runtime.Scheme) error {
+			return nil
+		})
+
+	err = schemeBuilder.AddToScheme(types)
+	if err != nil {
+		return nil, err
+	}
+
+	osConfig := rest.Config{
+		Host:    config.Host,
+		APIPath: "/apis",
+		ContentConfig: rest.ContentConfig{
+			GroupVersion:         &osRouteGroupVersion,
+			NegotiatedSerializer: serializer.DirectCodecFactory{CodecFactory: serializer.NewCodecFactory(types)},
+			ContentType:          runtime.ContentTypeJSON,
+		},
+		BearerToken:     config.BearerToken,
+		TLSClientConfig: config.TLSClientConfig,
+		QPS:             k8sQPS,
+		Burst:           k8sBurst,
+	}
+
+	client, err := rest.RESTClientFor(&osConfig)
+	if err != nil {
+		return nil, err
+	}
+	return &OSRouteClient{
+		client: client,
+	}, nil
+}
+
+// GetRoute returns an OpenShift route URL for the given name
+func (in *OSRouteClient) GetRoute(namespace string, routeName string) (string, error) {
+	result, err := in.client.Get().Namespace(namespace).Resource("routes").SubResource(routeName).Do().Raw()
+	if err != nil {
+		return "", err
+	}
+	var obj interface{}
+	err = json.Unmarshal(result, &obj)
+	if err != nil {
+		return "", err
+	}
+	spec, ok := obj.(map[string]interface{})["spec"]
+	if !ok {
+		return "", errors.New("Missing spec in Route")
+	}
+	host, ok := spec.(map[string]interface{})["host"].(string)
+	if !ok {
+		return "", errors.New("Missing host in Route spec")
+	}
+	// Manage https?
+	return "http://" + host, nil
+}

--- a/kubernetes/types.go
+++ b/kubernetes/types.go
@@ -7,31 +7,33 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
-// Sync these constants with the Istio version, it is uniform but probably it might change on major Istio vesions.
-const IstioAPIGroup = "config.istio.io"
-const IstioAPIVersion = "v1alpha2"
-
-var IstioGroupVersion = schema.GroupVersion{
-	Group:   IstioAPIGroup,
-	Version: IstioAPIVersion,
-}
-
-// This is used to tell Istio REST client which objects are supported for decoding.
-// When adding a new Istio type we should add a new object here.
-var KnownTypes = map[string]struct {
-	object     IstioObject
-	collection IstioObjectList
-}{
-	RouteRuleLabel: {
-		object: &RouteRule{
-			TypeMeta: meta_v1.TypeMeta{
-				Kind:       RouteRuleType,
-				APIVersion: IstioGroupVersion.Group + "/" + IstioGroupVersion.Version,
+var (
+	// Sync these constants with the Istio version, it is uniform but probably it might change on major Istio vesions.
+	istioGroupVersion = schema.GroupVersion{
+		Group:   "config.istio.io",
+		Version: "v1alpha2",
+	}
+	// This is used to tell Istio REST client which objects are supported for decoding.
+	// When adding a new Istio type we should add a new object here.
+	istioKnownTypes = map[string]struct {
+		object     IstioObject
+		collection IstioObjectList
+	}{
+		RouteRuleLabel: {
+			object: &RouteRule{
+				TypeMeta: meta_v1.TypeMeta{
+					Kind:       RouteRuleType,
+					APIVersion: istioGroupVersion.Group + "/" + istioGroupVersion.Version,
+				},
 			},
+			collection: &RouteRuleList{},
 		},
-		collection: &RouteRuleList{},
-	},
-}
+	}
+	osRouteGroupVersion = schema.GroupVersion{
+		Group:   "route.openshift.io",
+		Version: "v1",
+	}
+)
 
 // IstioObject is a k8s wrapper interface for config objects
 // Taken from istio.io

--- a/models/grafana_info.go
+++ b/models/grafana_info.go
@@ -2,6 +2,9 @@ package models
 
 // GrafanaInfo provides information to access Grafana dashboards
 type GrafanaInfo struct {
-	URL             string `json:"url"`
-	VariablesSuffix string `json:"variablesSuffix"`
+	URL              string `json:"url"`
+	VariablesSuffix  string `json:"variablesSuffix"`
+	Dashboard        string `json:"dashboard"`
+	VarServiceSource string `json:"varServiceSource"`
+	VarServiceDest   string `json:"varServiceDest"`
 }


### PR DESCRIPTION
- Can be disabled
- Can be taken from openshift route (a new "OSRouteClient" had to be created for that, similar to IstioClient)
- If not using openshift route or explicit config, look for k8s service "ExternalIPs" instead of "ClusterIP"
- Added ClusterRole to get Routes in openshift template
- Updated README