### PR TITLE
[SWS-213] errorRate should be calculated as rate, not percentage

### DIFF
--- a/graph/cytoscape/cytoscape.go
+++ b/graph/cytoscape/cytoscape.go
@@ -177,7 +177,7 @@ func addRpm(ed *EdgeData, sn *tree.ServiceNode) {
 	rpm := sn.Metadata["req_per_min"].(float64)
 	if rpm > 0.0 {
 		rpmSuccess := sn.Metadata["req_per_min_2xx"].(float64)
-		errorRate := (rpm - rpmSuccess) / rpm * 100.0
+		errorRate := (rpm - rpmSuccess) / rpm
 		switch {
 		case errorRate > 1.0:
 			ed.Color = "red"


### PR DESCRIPTION
The multiply by 100 should not happen.