### PR TITLE
SWS-245: [Hack scripts] Fix grafana service with istio-0.6.0

### DIFF
--- a/hack/istio/openshift/istio-install-openshift.sh
+++ b/hack/istio/openshift/istio-install-openshift.sh
@@ -46,11 +46,8 @@ oc adm policy add-scc-to-user privileged -z istio-pilot-service-account
 oc adm policy add-scc-to-user anyuid -z default
 oc adm policy add-scc-to-user privileged -z default
 oc adm policy add-cluster-role-to-user cluster-admin -z default
-oc adm policy add-scc-to-user anyuid -z istio-grafana-service-account
-oc adm policy add-scc-to-user privileged -z istio-pilot-service-account
-oc adm policy add-scc-to-user anyuid -z istio-prometheus-service-account
+oc adm policy add-scc-to-user anyuid -z grafana
 oc adm policy add-scc-to-user anyuid -z prometheus
-oc adm policy add-scc-to-user privileged -z istio-prometheus-service-account
 
 oc apply -f install/kubernetes/istio.yaml
 oc expose svc istio-ingress


### PR DESCRIPTION
Apparently the service-account name has been changed to just "grafana"
Also removed now unused service-account istio-prometheus-service-account, and duplicate lines

Note: without this change, I get this error while starting grafana pod:

```
jotak@cartago:/work/go/src/github.com/swift-sunshine/swscore (master %)$ oc logs grafana-4183644701-rcznr
chown: changing ownership of '/data/grafana': Operation not permitted
chown: changing ownership of '/var/log/grafana': Operation not permitted
```