### PR TITLE
SWS-249 Move to requests_per_second from requests_per_minute

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -95,7 +95,7 @@ make docker
 ==== Deploying SWS to OpenShift
 
 [NOTE]
-Before deploying and running SWS, you must install and deploy link:https://istio.io[Istio] first. There are a few places that you can reference in order to learn how to do this such as link:https://github.com/redhat-developer-demos/istio-tutorial[here], link:https://blog.openshift.com/evaluate-istio-openshift/[here], and link:https://istio.io/docs/setup/kubernetes/quick-start.html[here]. There is also a link:hack/istio/openshift[OpenShift script] provided to you as a convienence to help you install Istio if you are using OpenShift.
+Before deploying and running SWS, you must first install and deploy link:https://istio.io[Istio]. *Required Istio Version: 0.6.0+*. There are a few places that you can reference in order to learn how to do this such as link:https://github.com/redhat-developer-demos/istio-tutorial[here], link:https://blog.openshift.com/evaluate-istio-openshift/[here], and link:https://istio.io/docs/setup/kubernetes/quick-start.html[here]. There is also a link:hack/istio[convenience script] provided to you to help quickly get Istio installed.
 
 [NOTE]
 The following commands assume that the `oc` command is available in the user's path and that the user is logged in.
@@ -153,7 +153,7 @@ make minikube-docker
 ==== Deploying SWS to Kubernetes
 
 [NOTE]
-Before deploying and running SWS, you must install and deploy link:https://istio.io[Istio] first. There are a few places that you can reference in order to learn how to do this such as link:https://github.com/redhat-developer-demos/istio-tutorial[here], link:https://blog.openshift.com/evaluate-istio-openshift/[here], and link:https://istio.io/docs/setup/kubernetes/quick-start.html[here]. There is also a link:hack/istio/kubernetes[Kubernetes script] provided to you as a convienence to help you install Istio if you are using Kubernetes.
+Before deploying and running SWS, you must first install and deploy link:https://istio.io[Istio]. *Required Istio Version: 0.6.0+*. There are a few places that you can reference in order to learn how to do this such as link:https://github.com/redhat-developer-demos/istio-tutorial[here], link:https://blog.openshift.com/evaluate-istio-openshift/[here], and link:https://istio.io/docs/setup/kubernetes/quick-start.html[here]. There is also a link:hack/istio/kubernetes[Kubernetes script] provided to you as a convenience to help you install Istio if you are using Kubernetes.
 
 [NOTE]
 The following commands assume that the `kubectl` command is available in the user's path and that the user is logged in.

--- a/graph/options/options.go
+++ b/graph/options/options.go
@@ -1,0 +1,106 @@
+// Package options holds the currently supported path variables and query params
+// for the graph handlers. See graph package for details.
+package options
+
+import (
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/gorilla/mux"
+)
+
+// VendorOptions are those that arew supplied to the vendor-specific generators.
+type VendorOptions struct {
+	GroupByVersion bool
+	ColorDead      string
+	ColorError     string
+	ColorNormal    string
+	ColorWarn      string
+	ThresholdError float64
+	ThresholdWarn  float64
+}
+
+// Options are all supported graph generation options.
+type Options struct {
+	Namespace string
+	Service   string
+	Vendor    string
+	Metric    string
+	Offset    time.Duration
+	Interval  time.Duration
+	VendorOptions
+}
+
+func NewOptions(r *http.Request) Options {
+	// path variables
+	vars := mux.Vars(r)
+	namespace := vars["namespace"]
+	service := vars["service"]
+
+	// query params
+	params := r.URL.Query()
+	colorDead := params.Get("colorDead")
+	colorError := params.Get("colorError")
+	colorNormal := params.Get("colorNormal")
+	colorWarn := params.Get("colorWarn")
+	groupByVersion, groupByVersionErr := strconv.ParseBool(params.Get("groupByVersion"))
+	interval, intervalErr := time.ParseDuration(params.Get("interval"))
+	metric := params.Get("metric")
+	offset, offsetErr := time.ParseDuration(params.Get("offset"))
+	vendor := params.Get("vendor")
+	thresholdError, thresholdErrorErr := strconv.ParseFloat(params.Get("thresholdError"), 64)
+	thresholdWarn, thresholdWarnErr := strconv.ParseFloat(params.Get("thresholdWarn"), 64)
+
+	if "" == colorDead {
+		colorDead = "black"
+	}
+	if "" == colorError {
+		colorError = "red"
+	}
+	if "" == colorNormal {
+		colorNormal = "green"
+	}
+	if "" == colorWarn {
+		colorWarn = "orange"
+	}
+	if groupByVersionErr != nil {
+		groupByVersion = false // TODO: back to true after we get a decent layout
+	}
+	if intervalErr != nil {
+		interval, _ = time.ParseDuration("30s")
+	}
+	if "" == metric {
+		metric = "istio_request_count"
+	}
+	if offsetErr != nil {
+		offset, _ = time.ParseDuration("0m")
+	}
+	if "" == vendor {
+		vendor = "cytoscape"
+	}
+	if thresholdErrorErr != nil {
+		thresholdError = 0.2
+	}
+	if thresholdWarnErr != nil {
+		thresholdError = 0.0
+	}
+
+	return Options{
+		Namespace: namespace,
+		Service:   service,
+		Vendor:    vendor,
+		Interval:  interval,
+		Metric:    metric,
+		Offset:    offset,
+		VendorOptions: VendorOptions{
+			ColorDead:      colorDead,
+			ColorError:     colorError,
+			ColorNormal:    colorNormal,
+			ColorWarn:      colorWarn,
+			GroupByVersion: groupByVersion,
+			ThresholdError: thresholdError,
+			ThresholdWarn:  thresholdWarn,
+		},
+	}
+}

--- a/graph/tree/tree.go
+++ b/graph/tree/tree.go
@@ -9,7 +9,7 @@ import (
 )
 
 const (
-	UnknownName    = "internet"
+	UnknownService = "unknown"
 	UnknownVersion = "unknown"
 )
 

--- a/handlers/graph_test.go
+++ b/handlers/graph_test.go
@@ -72,9 +72,9 @@ func mockQuery(api *promAPIMock, query string, ret *model.Vector) {
 }
 
 func TestNamespaceGraph(t *testing.T) {
-	q0 := "sum(rate(istio_request_count{source_version=\"unknown\",destination_service=~\".*\\\\.istio-system\\\\..*\",response_code=~\"[2345][0-9][0-9]\"} [600s])) by (source_service)"
+	q0 := "sum(rate(istio_request_count{source_service=\"unknown\",source_version=\"unknown\",destination_service=~\".*\\\\.istio-system\\\\..*\",response_code=~\"[2345][0-9][0-9]\"} [30s])) by (source_service)"
 	q0m0 := model.Metric{
-		"source_service": ""}
+		"source_service": "unknown"}
 	q0m1 := model.Metric{
 		"source_service": "ingress.istio-system.svc.cluster.local"}
 	v0 := model.Vector{
@@ -85,7 +85,7 @@ func TestNamespaceGraph(t *testing.T) {
 			Metric: q0m1,
 			Value:  0}}
 
-	q1 := "sum(rate(istio_request_count{source_service=\"ingress.istio-system.svc.cluster.local\",source_version=\"unknown\",response_code=~\"[2345][0-9][0-9]\"} [600s]) * 60) by (destination_service,destination_version,response_code)"
+	q1 := "sum(rate(istio_request_count{source_service=\"ingress.istio-system.svc.cluster.local\",source_version=\"unknown\",response_code=~\"[2345][0-9][0-9]\"} [30s])) by (destination_service,destination_version,response_code)"
 	q1m0 := model.Metric{
 		"destination_service": "productpage.istio-system.svc.cluster.local",
 		"destination_version": "v1",
@@ -95,7 +95,7 @@ func TestNamespaceGraph(t *testing.T) {
 			Metric: q1m0,
 			Value:  100}}
 
-	q2 := "sum(rate(istio_request_count{source_service=\"\",source_version=\"unknown\",destination_service=~\".*\\\\.istio-system\\\\..*\",response_code=~\"[2345][0-9][0-9]\"} [600s]) * 60) by (destination_service,destination_version,response_code)"
+	q2 := "sum(rate(istio_request_count{source_service=\"unknown\",source_version=\"unknown\",destination_service=~\".*\\\\.istio-system\\\\..*\",response_code=~\"[2345][0-9][0-9]\"} [30s])) by (destination_service,destination_version,response_code)"
 	q2m0 := model.Metric{
 		"destination_service": "productpage.istio-system.svc.cluster.local",
 		"destination_version": "v1",
@@ -105,7 +105,7 @@ func TestNamespaceGraph(t *testing.T) {
 			Metric: q2m0,
 			Value:  50}}
 
-	q3 := "sum(rate(istio_request_count{source_service=\"productpage.istio-system.svc.cluster.local\",source_version=\"v1\",response_code=~\"[2345][0-9][0-9]\"} [600s]) * 60) by (destination_service,destination_version,response_code)"
+	q3 := "sum(rate(istio_request_count{source_service=\"productpage.istio-system.svc.cluster.local\",source_version=\"v1\",response_code=~\"[2345][0-9][0-9]\"} [30s])) by (destination_service,destination_version,response_code)"
 	q3m0 := model.Metric{
 		"destination_service": "reviews.istio-system.svc.cluster.local",
 		"destination_version": "v1",
@@ -143,10 +143,10 @@ func TestNamespaceGraph(t *testing.T) {
 			Metric: q3m4,
 			Value:  20}}
 
-	q4 := "sum(rate(istio_request_count{source_service=\"reviews.istio-system.svc.cluster.local\",source_version=\"v1\",response_code=~\"[2345][0-9][0-9]\"} [600s]) * 60) by (destination_service,destination_version,response_code)"
+	q4 := "sum(rate(istio_request_count{source_service=\"reviews.istio-system.svc.cluster.local\",source_version=\"v1\",response_code=~\"[2345][0-9][0-9]\"} [30s])) by (destination_service,destination_version,response_code)"
 	v4 := model.Vector{}
 
-	q5 := "sum(rate(istio_request_count{source_service=\"reviews.istio-system.svc.cluster.local\",source_version=\"v2\",response_code=~\"[2345][0-9][0-9]\"} [600s]) * 60) by (destination_service,destination_version,response_code)"
+	q5 := "sum(rate(istio_request_count{source_service=\"reviews.istio-system.svc.cluster.local\",source_version=\"v2\",response_code=~\"[2345][0-9][0-9]\"} [30s])) by (destination_service,destination_version,response_code)"
 	q5m0 := model.Metric{
 		"destination_service": "ratings.istio-system.svc.cluster.local",
 		"destination_version": "v1",
@@ -163,7 +163,7 @@ func TestNamespaceGraph(t *testing.T) {
 			Metric: q5m1,
 			Value:  20}}
 
-	q6 := "sum(rate(istio_request_count{source_service=\"reviews.istio-system.svc.cluster.local\",source_version=\"v3\",response_code=~\"[2345][0-9][0-9]\"} [600s]) * 60) by (destination_service,destination_version,response_code)"
+	q6 := "sum(rate(istio_request_count{source_service=\"reviews.istio-system.svc.cluster.local\",source_version=\"v3\",response_code=~\"[2345][0-9][0-9]\"} [30s])) by (destination_service,destination_version,response_code)"
 	q6m0 := model.Metric{
 		"destination_service": "ratings.istio-system.svc.cluster.local",
 		"destination_version": "v1",
@@ -180,10 +180,10 @@ func TestNamespaceGraph(t *testing.T) {
 			Metric: q6m1,
 			Value:  20}}
 
-	q7 := "sum(rate(istio_request_count{source_service=\"details.istio-system.svc.cluster.local\",source_version=\"v1\",response_code=~\"[2345][0-9][0-9]\"} [600s]) * 60) by (destination_service,destination_version,response_code)"
+	q7 := "sum(rate(istio_request_count{source_service=\"details.istio-system.svc.cluster.local\",source_version=\"v1\",response_code=~\"[2345][0-9][0-9]\"} [30s])) by (destination_service,destination_version,response_code)"
 	v7 := model.Vector{}
 
-	q8 := "sum(rate(istio_request_count{source_service=\"ratings.istio-system.svc.cluster.local\",source_version=\"v1\",response_code=~\"[2345][0-9][0-9]\"} [600s]) * 60) by (destination_service,destination_version,response_code)"
+	q8 := "sum(rate(istio_request_count{source_service=\"ratings.istio-system.svc.cluster.local\",source_version=\"v1\",response_code=~\"[2345][0-9][0-9]\"} [30s])) by (destination_service,destination_version,response_code)"
 	v8 := model.Vector{}
 
 	client, api, err := setupMocked()
@@ -229,7 +229,7 @@ func TestNamespaceGraph(t *testing.T) {
 }
 
 func TestServiceGraph(t *testing.T) {
-	q0 := "sum(rate(istio_request_count{destination_service=~\"reviews\\\\.istio-system\\\\..*\",response_code=~\"[2345][0-9][0-9]\"} [600s])) by (source_service, source_version)"
+	q0 := "sum(rate(istio_request_count{destination_service=~\"reviews\\\\.istio-system\\\\..*\",response_code=~\"[2345][0-9][0-9]\"} [30s])) by (source_service, source_version)"
 	q0m0 := model.Metric{
 		"source_service": "productpage.istio-system.svc.cluster.local",
 		"source_version": "v1"}
@@ -250,7 +250,7 @@ func TestServiceGraph(t *testing.T) {
 			Metric: q0m2,
 			Value:  20}}
 
-	q1 := "sum(rate(istio_request_count{source_service=\"productpage.istio-system.svc.cluster.local\",source_version=\"v1\",destination_service=~\"reviews\\\\.istio-system\\\\..*\",response_code=~\"[2345][0-9][0-9]\"} [600s]) * 60) by (destination_service,destination_version,response_code)"
+	q1 := "sum(rate(istio_request_count{source_service=\"productpage.istio-system.svc.cluster.local\",source_version=\"v1\",destination_service=~\"reviews\\\\.istio-system\\\\..*\",response_code=~\"[2345][0-9][0-9]\"} [30s])) by (destination_service,destination_version,response_code)"
 	q1m0 := model.Metric{
 		"destination_service": "reviews.istio-system.svc.cluster.local",
 		"destination_version": "v1",
@@ -274,10 +274,10 @@ func TestServiceGraph(t *testing.T) {
 			Metric: q1m2,
 			Value:  20}}
 
-	q2 := "sum(rate(istio_request_count{source_service=\"reviews.istio-system.svc.cluster.local\",source_version=\"v1\",destination_service=~\".*\\\\.istio-system\\\\..*\",response_code=~\"[2345][0-9][0-9]\"} [600s]) * 60) by (destination_service,destination_version,response_code)"
+	q2 := "sum(rate(istio_request_count{source_service=\"reviews.istio-system.svc.cluster.local\",source_version=\"v1\",destination_service=~\".*\\\\.istio-system\\\\..*\",response_code=~\"[2345][0-9][0-9]\"} [30s])) by (destination_service,destination_version,response_code)"
 	v2 := model.Vector{}
 
-	q3 := "sum(rate(istio_request_count{source_service=\"reviews.istio-system.svc.cluster.local\",source_version=\"v2\",destination_service=~\".*\\\\.istio-system\\\\..*\",response_code=~\"[2345][0-9][0-9]\"} [600s]) * 60) by (destination_service,destination_version,response_code)"
+	q3 := "sum(rate(istio_request_count{source_service=\"reviews.istio-system.svc.cluster.local\",source_version=\"v2\",destination_service=~\".*\\\\.istio-system\\\\..*\",response_code=~\"[2345][0-9][0-9]\"} [30s])) by (destination_service,destination_version,response_code)"
 	q3m0 := model.Metric{
 		"destination_service": "reviews.istio-system.svc.cluster.local",
 		"destination_version": "v2",
@@ -294,7 +294,7 @@ func TestServiceGraph(t *testing.T) {
 			Metric: q3m1,
 			Value:  20}}
 
-	q4 := "sum(rate(istio_request_count{source_service=\"reviews.istio-system.svc.cluster.local\",source_version=\"v3\",destination_service=~\".*\\\\.istio-system\\\\..*\",response_code=~\"[2345][0-9][0-9]\"} [600s]) * 60) by (destination_service,destination_version,response_code)"
+	q4 := "sum(rate(istio_request_count{source_service=\"reviews.istio-system.svc.cluster.local\",source_version=\"v3\",destination_service=~\".*\\\\.istio-system\\\\..*\",response_code=~\"[2345][0-9][0-9]\"} [30s])) by (destination_service,destination_version,response_code)"
 	q4m0 := model.Metric{
 		"destination_service": "reviews.istio-system.svc.cluster.local",
 		"destination_version": "v3",

--- a/handlers/testdata/test_namespace_graph.expected
+++ b/handlers/testdata/test_namespace_graph.expected
@@ -21,15 +21,6 @@
       },
       {
         "data": {
-          "id": "n0",
-          "text": "internet",
-          "service": "internet",
-          "version": "unknown",
-          "link_prom_graph": "http://prometheus:9090/graph?g0.range_input=1h\u0026g0.tab=0\u0026g0.expr=istio_request_count%7Bsource_service%3D%22%22%2Csource_version%3D%22unknown%22%7D"
-        }
-      },
-      {
-        "data": {
           "id": "n1",
           "text": "productpage (v1) \u003c20.00pm\u003e",
           "service": "productpage.istio-system.svc.cluster.local",
@@ -48,16 +39,8 @@
       },
       {
         "data": {
-          "id": "n8",
-          "text": "reviews",
-          "service": "reviews.istio-system.svc.cluster.local"
-        }
-      },
-      {
-        "data": {
           "id": "n3",
           "text": "reviews (v1)",
-          "parent": "n8",
           "service": "reviews.istio-system.svc.cluster.local",
           "version": "v1",
           "link_prom_graph": "http://prometheus:9090/graph?g0.range_input=1h\u0026g0.tab=0\u0026g0.expr=istio_request_count%7Bdestination_service%3D%22reviews.istio-system.svc.cluster.local%22%2Cdestination_version%3D%22v1%22%7D"
@@ -67,7 +50,6 @@
         "data": {
           "id": "n4",
           "text": "reviews (v2) \u003c20.00pm\u003e",
-          "parent": "n8",
           "service": "reviews.istio-system.svc.cluster.local",
           "version": "v2",
           "link_prom_graph": "http://prometheus:9090/graph?g0.range_input=1h\u0026g0.tab=0\u0026g0.expr=istio_request_count%7Bdestination_service%3D%22reviews.istio-system.svc.cluster.local%22%2Cdestination_version%3D%22v2%22%7D"
@@ -77,10 +59,18 @@
         "data": {
           "id": "n6",
           "text": "reviews (v3) \u003c20.00pm\u003e",
-          "parent": "n8",
           "service": "reviews.istio-system.svc.cluster.local",
           "version": "v3",
           "link_prom_graph": "http://prometheus:9090/graph?g0.range_input=1h\u0026g0.tab=0\u0026g0.expr=istio_request_count%7Bdestination_service%3D%22reviews.istio-system.svc.cluster.local%22%2Cdestination_version%3D%22v3%22%7D"
+        }
+      },
+      {
+        "data": {
+          "id": "n0",
+          "text": "unknown",
+          "service": "unknown",
+          "version": "unknown",
+          "link_prom_graph": "http://prometheus:9090/graph?g0.range_input=1h\u0026g0.tab=0\u0026g0.expr=istio_request_count%7Bsource_service%3D%22unknown%22%2Csource_version%3D%22unknown%22%7D"
         }
       }
     ],
@@ -90,7 +80,7 @@
           "id": "e0",
           "source": "n0",
           "target": "n1",
-          "text": "50.00pm",
+          "text": "50.00ps",
           "color": "green"
         }
       },
@@ -99,7 +89,7 @@
           "id": "e1",
           "source": "n1",
           "target": "n2",
-          "text": "20.00pm",
+          "text": "20.00ps",
           "color": "green"
         }
       },
@@ -108,7 +98,7 @@
           "id": "e2",
           "source": "n1",
           "target": "n3",
-          "text": "20.00pm",
+          "text": "20.00ps",
           "color": "green"
         }
       },
@@ -117,7 +107,7 @@
           "id": "e3",
           "source": "n1",
           "target": "n4",
-          "text": "20.00pm",
+          "text": "20.00ps",
           "color": "green"
         }
       },
@@ -126,7 +116,7 @@
           "id": "e5",
           "source": "n1",
           "target": "n6",
-          "text": "20.00pm",
+          "text": "20.00ps",
           "color": "green"
         }
       },
@@ -135,7 +125,7 @@
           "id": "e4",
           "source": "n4",
           "target": "n5",
-          "text": "20.00pm",
+          "text": "20.00ps",
           "color": "green"
         }
       },
@@ -144,7 +134,7 @@
           "id": "e6",
           "source": "n6",
           "target": "n5",
-          "text": "20.00pm",
+          "text": "20.00ps",
           "color": "green"
         }
       },
@@ -153,7 +143,7 @@
           "id": "e7",
           "source": "n7",
           "target": "n1",
-          "text": "100.00pm",
+          "text": "100.00ps",
           "color": "green"
         }
       }

--- a/handlers/testdata/test_service_graph.expected
+++ b/handlers/testdata/test_service_graph.expected
@@ -21,16 +21,8 @@
       },
       {
         "data": {
-          "id": "n5",
-          "text": "reviews",
-          "service": "reviews.istio-system.svc.cluster.local"
-        }
-      },
-      {
-        "data": {
           "id": "n1",
           "text": "reviews (v1)",
-          "parent": "n5",
           "service": "reviews.istio-system.svc.cluster.local",
           "version": "v1",
           "link_prom_graph": "http://prometheus:9090/graph?g0.range_input=1h\u0026g0.tab=0\u0026g0.expr=istio_request_count%7Bdestination_service%3D%22reviews.istio-system.svc.cluster.local%22%2Cdestination_version%3D%22v1%22%7D"
@@ -40,7 +32,6 @@
         "data": {
           "id": "n2",
           "text": "reviews (v2) \u003c20.00pm\u003e",
-          "parent": "n5",
           "service": "reviews.istio-system.svc.cluster.local",
           "version": "v2",
           "link_prom_graph": "http://prometheus:9090/graph?g0.range_input=1h\u0026g0.tab=0\u0026g0.expr=istio_request_count%7Bdestination_service%3D%22reviews.istio-system.svc.cluster.local%22%2Cdestination_version%3D%22v2%22%7D"
@@ -50,7 +41,6 @@
         "data": {
           "id": "n4",
           "text": "reviews (v3) \u003c20.00pm\u003e",
-          "parent": "n5",
           "service": "reviews.istio-system.svc.cluster.local",
           "version": "v3",
           "link_prom_graph": "http://prometheus:9090/graph?g0.range_input=1h\u0026g0.tab=0\u0026g0.expr=istio_request_count%7Bdestination_service%3D%22reviews.istio-system.svc.cluster.local%22%2Cdestination_version%3D%22v3%22%7D"
@@ -63,7 +53,7 @@
           "id": "e0",
           "source": "n0",
           "target": "n1",
-          "text": "20.00pm",
+          "text": "20.00ps",
           "color": "green"
         }
       },
@@ -72,7 +62,7 @@
           "id": "e1",
           "source": "n0",
           "target": "n2",
-          "text": "20.00pm",
+          "text": "20.00ps",
           "color": "green"
         }
       },
@@ -81,7 +71,7 @@
           "id": "e3",
           "source": "n0",
           "target": "n4",
-          "text": "20.00pm",
+          "text": "20.00ps",
           "color": "green"
         }
       },
@@ -90,7 +80,7 @@
           "id": "e2",
           "source": "n2",
           "target": "n3",
-          "text": "20.00pm",
+          "text": "20.00ps",
           "color": "green"
         }
       },
@@ -99,7 +89,7 @@
           "id": "e4",
           "source": "n4",
           "target": "n3",
-          "text": "20.00pm",
+          "text": "20.00ps",
           "color": "green"
         }
       }


### PR DESCRIPTION

NOTE: REQUIRES ISTIO 0.6.0 +

A few other changes here:
- refactor options to its own package
- be more clear about rate vs percentage in naming
- add rate_per_second query param support for thresholds and colors
- refactor vendor grpah generation to handle new istio 0.6 changes
  - source_service="" is now source_service="unknown"
  - the "unknown" service now serves as single root (is now parent of ingress)