### PR TITLE
SWS-261 Refactor metrics backend to provide range metrics

### DIFF
--- a/handlers/graph_test.go
+++ b/handlers/graph_test.go
@@ -1,16 +1,15 @@
 package handlers
 
 import (
-	"context"
 	"fmt"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"testing"
-	"time"
+
+	"github.com/swift-sunshine/swscore/prometheus/prometheustest"
 
 	"github.com/gorilla/mux"
-	"github.com/prometheus/client_golang/api/prometheus/v1"
 	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -21,33 +20,9 @@ import (
 
 // Setup mock
 
-type promAPIMock struct {
-	mock.Mock
-}
-
-func (o *promAPIMock) Query(ctx context.Context, query string, ts time.Time) (model.Value, error) {
-	args := o.Called(ctx, query, ts)
-	return args.Get(0).(model.Value), args.Error(1)
-}
-
-func (o *promAPIMock) QueryRange(ctx context.Context, query string, r v1.Range) (model.Value, error) {
-	args := o.Called(ctx, query, r)
-	return args.Get(0).(model.Value), args.Error(1)
-}
-
-func (o *promAPIMock) LabelValues(ctx context.Context, label string) (model.LabelValues, error) {
-	args := o.Called(ctx, label)
-	return args.Get(0).(model.LabelValues), args.Error(1)
-}
-
-func (o *promAPIMock) Series(ctx context.Context, matches []string, startTime time.Time, endTime time.Time) ([]model.LabelSet, error) {
-	args := o.Called(ctx, matches, startTime, endTime)
-	return args.Get(0).([]model.LabelSet), args.Error(1)
-}
-
-func setupMocked() (*prometheus.Client, *promAPIMock, error) {
+func setupMocked() (*prometheus.Client, *prometheustest.PromAPIMock, error) {
 	config.Set(config.NewConfig())
-	api := new(promAPIMock)
+	api := new(prometheustest.PromAPIMock)
 	client, err := prometheus.NewClient()
 	if err != nil {
 		return nil, nil, err
@@ -56,7 +31,7 @@ func setupMocked() (*prometheus.Client, *promAPIMock, error) {
 	return client, api, nil
 }
 
-func mockQuery(api *promAPIMock, query string, ret *model.Vector) {
+func mockQuery(api *prometheustest.PromAPIMock, query string, ret *model.Vector) {
 	api.On(
 		"Query",
 		mock.AnythingOfType("*context.emptyCtx"),

--- a/handlers/services_test.go
+++ b/handlers/services_test.go
@@ -1,30 +1,181 @@
 package handlers
 
 import (
-	"github.com/swift-sunshine/swscore/config"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/swift-sunshine/swscore/prometheus/prometheustest"
+
+	"github.com/prometheus/client_golang/api/prometheus/v1"
+	"github.com/stretchr/testify/mock"
+
+	"github.com/gorilla/mux"
+	"github.com/stretchr/testify/assert"
+	"github.com/swift-sunshine/swscore/prometheus"
 )
 
-func setupConfig() {
-	conf := config.NewConfig()
-	conf.PrometheusServiceURL = "http://prometheus-istio-system.127.0.0.1.nip.io"
-	config.Set(conf)
+// TestServiceMetricsDefault is unit test (testing request handling, not the prometheus client behaviour)
+func TestServiceMetricsDefault(t *testing.T) {
+	ts, api := setupServiceMetricsEndpoint(t)
+	defer ts.Close()
+
+	coveredPaths := 0
+	url := ts.URL + "/api/namespaces/ns/services/svc/metrics"
+	now := time.Now()
+	delta := 2 * time.Second
+
+	api.SpyArgumentsAndReturnEmpty(func(args mock.Arguments) {
+		switch r := args[2].(type) {
+		case time.Time:
+			// Health = envoy metrics
+			assert.Contains(t, args[1], "svc_ns_svc_cluster_local")
+			assert.WithinDuration(t, now, r, delta)
+			coveredPaths |= 2
+		case v1.Range:
+			// Other metrics = Istio metrics
+			assert.Contains(t, args[1], "svc.ns.svc.cluster.local")
+			assert.Contains(t, args[1], "["+metricsDefaultRateInterval+"]")
+			assert.Equal(t, metricsDefaultStepSec*time.Second, r.Step)
+			assert.WithinDuration(t, now, r.End, delta)
+			assert.WithinDuration(t, now.Add(-metricsDefaultDurationMin*time.Minute), r.Start, delta)
+			coveredPaths |= 1
+		}
+	})
+
+	resp, err := http.Get(url)
+	if err != nil {
+		t.Fatal(err)
+	}
+	actual, _ := ioutil.ReadAll(resp.Body)
+
+	assert.NotEmpty(t, actual)
+	assert.Equal(t, 200, resp.StatusCode, string(actual))
+	assert.Equal(t, 3, coveredPaths)
 }
 
-// Integration test. Manual for the moment.
-// func TestGetServiceMetrics(t *testing.T) {
-// 	setupConfig()
-// 	startServer()
-// 	// Open up your browser and hit http://127.0.0.1:8000/api/namespaces/tutorial/services/preference/metrics
-// }
+func TestServiceMetricsWithParams(t *testing.T) {
+	ts, api := setupServiceMetricsEndpoint(t)
+	defer ts.Close()
 
-// func startServer() {
-// 	conf := config.Get()
-// 	router := routing.NewRouter(conf)
-// 	srv := &http.Server{
-// 		Handler:      router,
-// 		Addr:         "127.0.0.1:8000",
-// 		WriteTimeout: 15 * time.Second,
-// 		ReadTimeout:  15 * time.Second,
-// 	}
-// 	log.Fatal(srv.ListenAndServe())
-// }
+	req, err := http.NewRequest("GET", ts.URL+"/api/namespaces/ns/services/svc/metrics", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	q := req.URL.Query()
+	q.Add("rateInterval", "5h")
+	q.Add("step", "99")
+	q.Add("duration", "1000")
+	req.URL.RawQuery = q.Encode()
+
+	coveredPaths := 0
+	now := time.Now()
+	delta := 2 * time.Second
+
+	api.SpyArgumentsAndReturnEmpty(func(args mock.Arguments) {
+		switch r := args[2].(type) {
+		case time.Time:
+			// Health = envoy metrics
+			assert.WithinDuration(t, now, r, delta)
+			coveredPaths |= 2
+		case v1.Range:
+			// Other metrics = Istio metrics
+			assert.Contains(t, args[1], "[5h]")
+			assert.Equal(t, 99*time.Second, r.Step)
+			assert.WithinDuration(t, now, r.End, delta)
+			assert.WithinDuration(t, now.Add(-1000*time.Second), r.Start, delta)
+			coveredPaths |= 1
+		}
+	})
+
+	httpclient := &http.Client{}
+	resp, err := httpclient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	actual, _ := ioutil.ReadAll(resp.Body)
+
+	assert.NotEmpty(t, actual)
+	assert.Equal(t, 200, resp.StatusCode, string(actual))
+	assert.Equal(t, 3, coveredPaths)
+}
+
+func TestServiceMetricsBadDuration(t *testing.T) {
+	ts, api := setupServiceMetricsEndpoint(t)
+	defer ts.Close()
+
+	req, err := http.NewRequest("GET", ts.URL+"/api/namespaces/ns/services/svc/metrics", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	q := req.URL.Query()
+	q.Add("rateInterval", "5h")
+	q.Add("step", "99")
+	q.Add("duration", "abc")
+	req.URL.RawQuery = q.Encode()
+
+	api.SpyArgumentsAndReturnEmpty(func(args mock.Arguments) {
+		// Make sure there's no client call and we fail fast
+		t.Error("Unexpected call to client while having bad request")
+	})
+
+	httpclient := &http.Client{}
+	resp, err := httpclient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	actual, _ := ioutil.ReadAll(resp.Body)
+
+	assert.Equal(t, 400, resp.StatusCode)
+	assert.Contains(t, string(actual), "cannot parse query parameter 'duration'")
+}
+
+func TestServiceMetricsBadStep(t *testing.T) {
+	ts, api := setupServiceMetricsEndpoint(t)
+	defer ts.Close()
+
+	req, err := http.NewRequest("GET", ts.URL+"/api/namespaces/ns/services/svc/metrics", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	q := req.URL.Query()
+	q.Add("rateInterval", "5h")
+	q.Add("step", "abc")
+	q.Add("duration", "1000")
+	req.URL.RawQuery = q.Encode()
+
+	api.SpyArgumentsAndReturnEmpty(func(args mock.Arguments) {
+		// Make sure there's no client call and we fail fast
+		t.Error("Unexpected call to client while having bad request")
+	})
+
+	httpclient := &http.Client{}
+	resp, err := httpclient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	actual, _ := ioutil.ReadAll(resp.Body)
+
+	assert.Equal(t, 400, resp.StatusCode)
+	assert.Contains(t, string(actual), "cannot parse query parameter 'step'")
+}
+
+func setupServiceMetricsEndpoint(t *testing.T) (*httptest.Server, *prometheustest.PromAPIMock) {
+	client, api, err := setupMocked()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	mr := mux.NewRouter()
+	mr.HandleFunc("/api/namespaces/{namespace}/services/{service}/metrics", http.HandlerFunc(
+		func(w http.ResponseWriter, r *http.Request) {
+			getServiceMetrics(w, r, func() (*prometheus.Client, error) {
+				return client, nil
+			})
+		}))
+
+	ts := httptest.NewServer(mr)
+	return ts, api
+}

--- a/prometheus/prometheustest/mock.go
+++ b/prometheus/prometheustest/mock.go
@@ -1,0 +1,84 @@
+package prometheustest
+
+import (
+	"context"
+	"time"
+
+	"github.com/prometheus/client_golang/api/prometheus/v1"
+	"github.com/prometheus/common/model"
+	"github.com/stretchr/testify/mock"
+)
+
+// PromAPIMock for mocking Prometheus API
+type PromAPIMock struct {
+	mock.Mock
+}
+
+func (o *PromAPIMock) Query(ctx context.Context, query string, ts time.Time) (model.Value, error) {
+	args := o.Called(ctx, query, ts)
+	return args.Get(0).(model.Value), args.Error(1)
+}
+
+func (o *PromAPIMock) QueryRange(ctx context.Context, query string, r v1.Range) (model.Value, error) {
+	args := o.Called(ctx, query, r)
+	return args.Get(0).(model.Value), args.Error(1)
+}
+
+func (o *PromAPIMock) LabelValues(ctx context.Context, label string) (model.LabelValues, error) {
+	args := o.Called(ctx, label)
+	return args.Get(0).(model.LabelValues), args.Error(1)
+}
+
+func (o *PromAPIMock) Series(ctx context.Context, matches []string, startTime time.Time, endTime time.Time) ([]model.LabelSet, error) {
+	args := o.Called(ctx, matches, startTime, endTime)
+	return args.Get(0).([]model.LabelSet), args.Error(1)
+}
+
+// AlwaysReturnEmpty mocks all possible queries to return empty result
+func (o *PromAPIMock) AlwaysReturnEmpty() {
+	metric := model.Metric{
+		"__name__": "whatever",
+		"instance": "whatever",
+		"job":      "whatever"}
+	o.On(
+		"Query",
+		mock.AnythingOfType("*context.emptyCtx"),
+		mock.AnythingOfType("string"),
+		mock.AnythingOfType("time.Time"),
+	).Return(model.Vector{}, nil)
+	matrix := model.Matrix{
+		&model.SampleStream{
+			Metric: metric,
+			Values: []model.SamplePair{}}}
+	o.On(
+		"QueryRange",
+		mock.AnythingOfType("*context.emptyCtx"),
+		mock.AnythingOfType("string"),
+		mock.AnythingOfType("v1.Range"),
+	).Return(matrix, nil)
+}
+
+// SpyArgumentsAndReturnEmpty mocks all possible queries to return empty result,
+// allowing to spy arguments through input callback
+func (o *PromAPIMock) SpyArgumentsAndReturnEmpty(fn func(args mock.Arguments)) {
+	metric := model.Metric{
+		"__name__": "whatever",
+		"instance": "whatever",
+		"job":      "whatever"}
+	o.On(
+		"Query",
+		mock.AnythingOfType("*context.emptyCtx"),
+		mock.AnythingOfType("string"),
+		mock.AnythingOfType("time.Time"),
+	).Run(fn).Return(model.Vector{}, nil)
+	matrix := model.Matrix{
+		&model.SampleStream{
+			Metric: metric,
+			Values: []model.SamplePair{}}}
+	o.On(
+		"QueryRange",
+		mock.AnythingOfType("*context.emptyCtx"),
+		mock.AnythingOfType("string"),
+		mock.AnythingOfType("v1.Range"),
+	).Run(fn).Return(matrix, nil)
+}


### PR DESCRIPTION
- ServiceMetrics handler: add duration and step query params
- Prometheus client: refactor channels usage, refactor model, provide Health with a dedicated model, fetch ranges
- Tests: share prometheus API mock. Use it in prom's client_test, graph_test, services_test
- Tests: update client tests for ranges, test empty metrics, test ServiceMetrics handler