### PR TITLE
Allow to specify a default OPENSHIFT_IP_ADDRESS for the hack scripts

### DIFF
--- a/hack/env-openshift.sh
+++ b/hack/env-openshift.sh
@@ -13,7 +13,7 @@ OPENSHIFT_GOPATH=${HOME}/source/go/openshift
 # This is the IP address where OpenShift will bind its master.
 # This should be a valid IP address for the machine where OpenShift is installed.
 # NOTE: Do not use any IP address within the loopback range of 127.0.0.x.
-OPENSHIFT_IP_ADDRESS=$(ip -f inet addr | grep 'state UP' -A1 | tail -n1 | awk '{print $2}' | cut -f1 -d'/')
+OPENSHIFT_IP_ADDRESS=${OPENSHIFT_IP_ADDRESS:-`echo $(ip -f inet addr | grep 'state UP' -A1 | tail -n1 | awk '{print $2}' | cut -f1 -d'/')`}
 
 # If you want to run the last release of OpenShift, use "latest" or "master".
 # If you want to run with a specific version, set it to the branch you want.


### PR DESCRIPTION
Allows to set a value for OPENSHIFT_IP_ADDRESS that will be used by the hack scripts.

e.g.
`export OPENSHIFT_IP_ADDRESS="192.168.16.1"; ./cluster-openshift.sh up`