### PR TITLE
SWS-261 Remove abusing usage of channels

### DIFF
--- a/handlers/services.go
+++ b/handlers/services.go
@@ -20,6 +20,12 @@ const (
 	metricsDefaultDurationMin  = 30
 )
 
+// HealthAndMetrics contains health, all simple metrics and histograms data - for json export only
+type healthAndMetrics struct {
+	Metrics prometheus.Metrics `json:"metrics"`
+	Health  prometheus.Health  `json:"health"`
+}
+
 // ServiceList is the API handler to fetch the list of services in a given namespace
 func ServiceList(w http.ResponseWriter, r *http.Request) {
 	params := mux.Vars(r)
@@ -77,8 +83,10 @@ func getServiceMetrics(w http.ResponseWriter, r *http.Request, promClientSupplie
 		RespondWithError(w, http.StatusServiceUnavailable, "Prometheus client error: "+err.Error())
 		return
 	}
-	metrics := prometheusClient.GetServiceMetrics(namespace, service, duration, step, rateInterval)
-	RespondWithJSON(w, http.StatusOK, metrics)
+	metrics, health := prometheusClient.GetServiceMetrics(namespace, service, duration, step, rateInterval)
+	RespondWithJSON(w, http.StatusOK, healthAndMetrics{
+		Metrics: metrics,
+		Health:  health})
 }
 
 // ServiceDetails is the API handler to fetch full details of an specific service

--- a/prometheus/client.go
+++ b/prometheus/client.go
@@ -86,17 +86,12 @@ func (in *Client) GetSourceServices(namespace string, servicename string) (map[s
 // GetServiceMetrics returns the Health and Metrics related to the provided service identified by its namespace and service name.
 // Health might be nil when unavailable
 func (in *Client) GetServiceMetrics(namespace string, servicename string, duration time.Duration, step time.Duration,
-	rateInterval string) Metrics {
+	rateInterval string) (Metrics, Health) {
 
-	healthChan, metricsChan := make(chan *Health), make(chan Metrics)
-	go getServiceHealthAsync(in.api, namespace, servicename, healthChan)
-	go getServiceMetricsAsync(in.api, namespace, servicename, duration, step, rateInterval, metricsChan)
+	metrics := getServiceMetrics(in.api, namespace, servicename, duration, step, rateInterval)
+	health := getServiceHealth(in.api, namespace, servicename)
 
-	// Merge health in metrics
-	metrics := <-metricsChan
-	metrics.Health = <-healthChan
-
-	return metrics
+	return metrics, health
 }
 
 // API returns the Prometheus V1 HTTP API for performing calls not supported natively by this client


### PR DESCRIPTION
Simple synchronization between goroutines is better done through async.WaitGroup
Also removed some async calls where it seems like overkill