### PR TITLE
enhance istio-installer to better prepare ansible

### DIFF
--- a/hack/istio/istio-install.sh
+++ b/hack/istio/istio-install.sh
@@ -16,6 +16,16 @@ if [ "$?" != 0 ]; then
     echo "You do not have Ansible installed yet - attempting to install a local copy at $ANSIBLE_DIR"
     cd $OUTPUT_DIR && git clone git://github.com/ansible/ansible.git --recursive
     echo "Ansible has been downloaded here: ${ANSIBLE_DIR}"
+    echo "Will now attempt to pip install required dependencies."
+    pip install -r ${ANSIBLE_DIR}/requirements.txt > /dev/null 2>&1
+    if [ "$?" != 0 ]; then
+      echo "==========================================================="
+      echo "Looks like some Python dependencies might not be installed."
+      echo "If you get errors while trying to install and run Istio,"
+      echo "run this command and then re-run this script:"
+      echo "   sudo pip install -r ${ANSIBLE_DIR}/requirements.txt"
+      echo "==========================================================="
+    fi
   fi
   echo "Setting up environment to use the local installation of Ansible"
   source ${ANSIBLE_ENV_SETUP_SCRIPT}


### PR DESCRIPTION
When installing Ansible from source, the ansible docs tell you to install some python deps via pip. This 
script now does that. If you already have the deps installed, the script keeps going. Note even if the pip-install fails, the script keeps going - it is possible you need to sudo the pip call - but since it might have already been done by the root user, this script keeps going in the hopes of being successful. A warning message is output just to let the user know what is going on in that case.

@jshaughn hit this - he didn't have some of those python deps installed so even after git cloning ansible, the ansible scripts failed to run properly.